### PR TITLE
Localize preview status copy

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,117 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "pi-markdown-preview",
+		messages: {
+			"cmd.preview": "レンダリング済み Markdown プレビュー (--pick で応答選択、--file <path> またはパス、--browser で HTML、--pdf で PDF、--terminal でインライン強制、--font-size <px>)",
+			"cmd.browser": "レンダリング済み Markdown + LaTeX プレビューを既定ブラウザーで開く (MathML + 必要時のみ MathJax)",
+			"cmd.pdf": "pandoc + LaTeX で Markdown を PDF に出力して開く",
+			"cmd.clearCache": "レンダリング済みプレビューキャッシュをクリア (~/.pi/cache/markdown-preview)",
+			"notify.noAssistantMarkdown": "現在のブランチに assistant の Markdown がありません。",
+			"notify.noAssistantMessages": "現在のブランチに assistant メッセージがありません。",
+			"notify.previewFailed": "プレビューに失敗しました: {message}",
+			"notify.previewCancelled": "プレビューをキャンセルしました。",
+			"notify.openedBrowser": "ブラウザープレビューを開きました。",
+			"notify.browserFailed": "ブラウザープレビューに失敗しました: {message}",
+			"notify.openedPdf": "PDF プレビューを開きました。",
+			"notify.pdfFailed": "PDF 出力に失敗しました: {message}",
+			"notify.cacheCleared": "プレビューキャッシュをクリアしました: {path}",
+			"notify.cacheClearFailed": "プレビューキャッシュのクリアに失敗しました: {message}",
+			"picker.title": "プレビューする応答を選択",
+			"picker.controls": "↑↓ 移動 • enter 選択 • esc キャンセル",
+			"overlay.opening": "ブラウザープレビューを開いています...",
+			"overlay.opened": "ブラウザーでプレビューを開きました。",
+			"overlay.openFailed": "ブラウザーで開けませんでした: {message}",
+			"overlay.refreshing": "現在のテーマでプレビューを更新しています...",
+			"overlay.refreshed": "更新しました ({mode} mode)。",
+			"overlay.refreshFailed": "更新に失敗しました: {message}",
+			"loader.rendering": "Markdown + LaTeX プレビューをレンダリング中...",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "pi-markdown-preview",
+		messages: {
+			"cmd.preview": "渲染 Markdown 预览（--pick 选择回复，--file <path> 或直接路径，--browser 输出 HTML，--pdf 输出 PDF，--terminal 强制内联，--font-size <px>）",
+			"cmd.browser": "在默认浏览器中打开渲染后的 Markdown + LaTeX 预览（MathML + 必要时 MathJax）",
+			"cmd.pdf": "通过 pandoc + LaTeX 将 Markdown 导出为 PDF 并打开",
+			"cmd.clearCache": "清除渲染预览缓存（~/.pi/cache/markdown-preview）",
+			"notify.noAssistantMarkdown": "当前分支中没有 assistant Markdown。",
+			"notify.noAssistantMessages": "当前分支中没有 assistant 消息。",
+			"notify.previewFailed": "预览失败: {message}",
+			"notify.previewCancelled": "已取消预览。",
+			"notify.openedBrowser": "已在浏览器中打开预览。",
+			"notify.browserFailed": "浏览器预览失败: {message}",
+			"notify.openedPdf": "已打开 PDF 预览。",
+			"notify.pdfFailed": "PDF 导出失败: {message}",
+			"notify.cacheCleared": "已清除预览缓存: {path}",
+			"notify.cacheClearFailed": "清除预览缓存失败: {message}",
+			"picker.title": "选择要预览的回复",
+			"picker.controls": "↑↓ 导航 • enter 选择 • esc 取消",
+			"overlay.opening": "正在打开浏览器预览...",
+			"overlay.opened": "已在浏览器中打开预览。",
+			"overlay.openFailed": "浏览器打开失败: {message}",
+			"overlay.refreshing": "正在按当前主题刷新预览...",
+			"overlay.refreshed": "已刷新（{mode} mode）。",
+			"overlay.refreshFailed": "刷新失败: {message}",
+			"loader.rendering": "正在渲染 Markdown + LaTeX 预览...",
+		},
+	},
+	{
+		locale: "es",
+		namespace: "pi-markdown-preview",
+		messages: {
+			"cmd.preview": "Vista previa renderizada de Markdown (--pick selecciona respuesta, --file <path> o ruta directa, --browser para HTML, --pdf para PDF, --terminal fuerza inline, --font-size <px>)",
+			"cmd.browser": "Abrir vista previa renderizada de Markdown + LaTeX en el navegador predeterminado (MathML + fallback selectivo de MathJax)",
+			"cmd.pdf": "Exportar Markdown a PDF con pandoc + LaTeX y abrirlo",
+			"cmd.clearCache": "Borrar caché de vistas previas renderizadas (~/.pi/cache/markdown-preview)",
+			"notify.noAssistantMarkdown": "No se encontró Markdown del assistant en la rama actual.",
+			"notify.noAssistantMessages": "No se encontraron mensajes del assistant en la rama actual.",
+			"notify.previewFailed": "La vista previa falló: {message}",
+			"notify.previewCancelled": "Vista previa cancelada.",
+			"notify.openedBrowser": "Vista previa abierta en el navegador.",
+			"notify.browserFailed": "La vista previa en navegador falló: {message}",
+			"notify.openedPdf": "Vista previa PDF abierta.",
+			"notify.pdfFailed": "La exportación PDF falló: {message}",
+			"notify.cacheCleared": "Caché de vista previa borrada: {path}",
+			"notify.cacheClearFailed": "No se pudo borrar la caché de vista previa: {message}",
+			"picker.title": "Seleccionar respuesta para previsualizar",
+			"picker.controls": "↑↓ navegar • enter seleccionar • esc cancelar",
+			"overlay.opening": "Abriendo vista previa en navegador...",
+			"overlay.opened": "Vista previa abierta en el navegador.",
+			"overlay.openFailed": "No se pudo abrir el navegador: {message}",
+			"overlay.refreshing": "Actualizando vista previa para el tema actual...",
+			"overlay.refreshed": "Actualizado (modo {mode}).",
+			"overlay.refreshFailed": "La actualización falló: {message}",
+			"loader.rendering": "Renderizando vista previa Markdown + LaTeX...",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "pi-markdown-preview",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import {
 	replaceInlineAnnotationMarkers,
 	transformMarkdownOutsideFences,
 } from "./shared/annotation-scanner.js";
+import { initI18n, t } from "./i18n.js";
 
 const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
@@ -1759,17 +1760,17 @@ class MarkdownPreviewOverlay {
 
 		if (matchesKey(data, "o") && !this.isOpeningBrowser) {
 			this.isOpeningBrowser = true;
-			this.statusLine = this.theme.fg("warning", "Opening browser preview...");
+			this.statusLine = this.theme.fg("warning", t("overlay.opening", "Opening browser preview..."));
 			this.rebuild();
 			this.tui.requestRender();
 
 			void this.openInBrowser()
 				.then(() => {
-					this.statusLine = this.theme.fg("success", "Opened preview in browser.");
+					this.statusLine = this.theme.fg("success", t("overlay.opened", "Opened preview in browser."));
 				})
 				.catch((error) => {
 					const message = error instanceof Error ? error.message : String(error);
-					this.statusLine = this.theme.fg("error", `Browser open failed: ${message}`);
+					this.statusLine = this.theme.fg("error", t("overlay.openFailed", `Browser open failed: ${message}`, { message }));
 				})
 				.finally(() => {
 					this.isOpeningBrowser = false;
@@ -1781,7 +1782,7 @@ class MarkdownPreviewOverlay {
 
 		if (matchesKey(data, "r") && !this.isRefreshing) {
 			this.isRefreshing = true;
-			this.statusLine = this.theme.fg("warning", "Refreshing preview for current theme...");
+			this.statusLine = this.theme.fg("warning", t("overlay.refreshing", "Refreshing preview for current theme..."));
 			this.rebuild();
 			this.tui.requestRender();
 
@@ -1790,11 +1791,11 @@ class MarkdownPreviewOverlay {
 					this.clearRenderedImages();
 					this.preview = preview;
 					this.pageIndex = Math.min(this.pageIndex, Math.max(0, preview.pages.length - 1));
-					this.statusLine = this.theme.fg("success", `Refreshed (${preview.themeMode} mode).`);
+					this.statusLine = this.theme.fg("success", t("overlay.refreshed", `Refreshed (${preview.themeMode} mode).`, { mode: preview.themeMode }));
 				})
 				.catch((error) => {
 					const message = error instanceof Error ? error.message : String(error);
-					this.statusLine = this.theme.fg("error", `Refresh failed: ${message}`);
+					this.statusLine = this.theme.fg("error", t("overlay.refreshFailed", `Refresh failed: ${message}`, { message }));
 				})
 				.finally(() => {
 					this.isRefreshing = false;
@@ -1822,7 +1823,7 @@ async function renderWithLoader(ctx: ExtensionCommandContext, markdown: string, 
 	type LoaderResult = { ok: true; preview: RenderPreviewResult } | { ok: false; error: string } | { ok: false; cancelled: true };
 
 	const result = await ctx.ui.custom<LoaderResult>((tui, theme, _kb, done) => {
-		const loader = new BorderedLoader(tui, theme, "Rendering markdown + LaTeX preview...");
+		const loader = new BorderedLoader(tui, theme, t("loader.rendering", "Rendering markdown + LaTeX preview..."));
 		let settled = false;
 		const resolve = (value: LoaderResult) => {
 			if (settled) return;
@@ -1857,21 +1858,21 @@ async function renderWithLoader(ctx: ExtensionCommandContext, markdown: string, 
 			return { preview, supportsCustomUi: false };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			ctx.ui.notify(`Preview failed: ${message}`, "error");
+			ctx.ui.notify(t("notify.previewFailed", `Preview failed: ${message}`, { message }), "error");
 			return null;
 		}
 	}
 
 	if (!result.ok) {
 		if ("cancelled" in result && result.cancelled) {
-			ctx.ui.notify("Preview cancelled.", "info");
+			ctx.ui.notify(t("notify.previewCancelled", "Preview cancelled."), "info");
 			return null;
 		}
 		if ("error" in result) {
-			ctx.ui.notify(`Preview failed: ${result.error}`, "error");
+			ctx.ui.notify(t("notify.previewFailed", `Preview failed: ${result.error}`, { message: result.error }), "error");
 			return null;
 		}
-		ctx.ui.notify("Preview failed.", "error");
+		ctx.ui.notify(t("notify.previewFailedGeneric", "Preview failed."), "error");
 		return null;
 	}
 
@@ -1885,7 +1886,7 @@ async function pickAssistantMessage(ctx: ExtensionCommandContext): Promise<strin
 	const messages = getAssistantMessages(ctx);
 
 	if (messages.length === 0) {
-		ctx.ui.notify("No assistant messages found in the current branch.", "warning");
+		ctx.ui.notify(t("notify.noAssistantMessages", "No assistant messages found in the current branch."), "warning");
 		return null;
 	}
 
@@ -1902,7 +1903,7 @@ async function pickAssistantMessage(ctx: ExtensionCommandContext): Promise<strin
 	const result = await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {
 		const container = new Container();
 		container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
-		container.addChild(new Text(theme.fg("accent", theme.bold("Select Response to Preview")), 1, 0));
+		container.addChild(new Text(theme.fg("accent", theme.bold(t("picker.title", "Select Response to Preview"))), 1, 0));
 
 		const selectList = new SelectList(items, Math.min(items.length, 10), {
 			selectedPrefix: (text) => theme.fg("accent", text),
@@ -1921,7 +1922,7 @@ async function pickAssistantMessage(ctx: ExtensionCommandContext): Promise<strin
 		selectList.onCancel = () => done(null);
 		container.addChild(selectList);
 
-		container.addChild(new Text(theme.fg("dim", "↑↓ navigate • enter select • esc cancel"), 1, 0));
+		container.addChild(new Text(theme.fg("dim", t("picker.controls", "↑↓ navigate • enter select • esc cancel")), 1, 0));
 		container.addChild(new DynamicBorder((s: string) => theme.fg("accent", s)));
 
 		return {
@@ -1946,7 +1947,7 @@ async function pickAssistantMessage(ctx: ExtensionCommandContext): Promise<strin
 async function openPreview(ctx: ExtensionCommandContext, markdownOverride?: string, resourcePath?: string, isLatex?: boolean, fontSizePx?: number): Promise<void> {
 	const markdown = markdownOverride ?? getLastAssistantMarkdown(ctx);
 	if (!markdown) {
-		ctx.ui.notify("No assistant markdown found in the current branch.", "warning");
+		ctx.ui.notify(t("notify.noAssistantMarkdown", "No assistant markdown found in the current branch."), "warning");
 		return;
 	}
 
@@ -2669,7 +2670,7 @@ async function preprocessMermaidForPdf(markdown: string): Promise<MermaidPdfPrep
 async function exportPdf(ctx: ExtensionCommandContext, markdownOverride?: string, resourcePath?: string, isLatex?: boolean): Promise<void> {
 	const markdown = markdownOverride ?? getLastAssistantMarkdown(ctx);
 	if (!markdown) {
-		ctx.ui.notify("No assistant markdown found in the current branch.", "warning");
+		ctx.ui.notify(t("notify.noAssistantMarkdown", "No assistant markdown found in the current branch."), "warning");
 		return;
 	}
 
@@ -3615,6 +3616,7 @@ function parsePreviewArgs(args: string): { target?: PreviewTarget; pick?: boolea
 }
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	const run = async (args: string, ctx: ExtensionCommandContext) => {
 		const parsed = parsePreviewArgs(args);
 		if (parsed.help) {
@@ -3669,10 +3671,10 @@ export default function (pi: ExtensionAPI) {
 		if (parsed.target === "browser") {
 			try {
 				await openPreviewInBrowser(ctx, markdown, resourcePath, isLatex, parsed.fontSizePx);
-				ctx.ui.notify("Opened preview in browser.", "info");
+				ctx.ui.notify(t("notify.openedBrowser", "Opened preview in browser."), "info");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Browser preview failed: ${message}`, "error");
+				ctx.ui.notify(t("notify.browserFailed", `Browser preview failed: ${message}`, { message }), "error");
 			}
 			return;
 		}
@@ -3680,10 +3682,10 @@ export default function (pi: ExtensionAPI) {
 		if (parsed.target === "pdf") {
 			try {
 				await exportPdf(ctx, markdown, resourcePath, isLatex);
-				ctx.ui.notify("Opened PDF preview.", "info");
+				ctx.ui.notify(t("notify.openedPdf", "Opened PDF preview."), "info");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`PDF export failed: ${message}`, "error");
+				ctx.ui.notify(t("notify.pdfFailed", `PDF export failed: ${message}`, { message }), "error");
 			}
 			return;
 		}
@@ -3692,12 +3694,12 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.registerCommand("preview", {
-		description: "Rendered markdown preview (--pick select response, --file <path> or bare path, --browser for HTML, --pdf for PDF, --terminal to force inline, --font-size <px>)",
+		description: t("cmd.preview", "Rendered markdown preview (--pick select response, --file <path> or bare path, --browser for HTML, --pdf for PDF, --terminal to force inline, --font-size <px>)"),
 		handler: run,
 	});
 
 	pi.registerCommand("preview-browser", {
-		description: "Open rendered markdown + LaTeX preview in the default browser (MathML + selective MathJax fallback)",
+		description: t("cmd.browser", "Open rendered markdown + LaTeX preview in the default browser (MathML + selective MathJax fallback)"),
 		handler: async (args, ctx) => {
 			await ctx.waitForIdle();
 			await run(`--browser ${args}`.trim(), ctx);
@@ -3705,7 +3707,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("preview-pdf", {
-		description: "Export markdown to PDF via pandoc + LaTeX and open it",
+		description: t("cmd.pdf", "Export markdown to PDF via pandoc + LaTeX and open it"),
 		handler: async (args, ctx) => {
 			await ctx.waitForIdle();
 			// Re-use the main run handler with --pdf prepended
@@ -3714,15 +3716,15 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("preview-clear-cache", {
-		description: "Clear rendered preview cache (~/.pi/cache/markdown-preview)",
+		description: t("cmd.clearCache", "Clear rendered preview cache (~/.pi/cache/markdown-preview)"),
 		handler: async (_args, ctx) => {
 			await ctx.waitForIdle();
 			try {
 				await rm(CACHE_DIR, { recursive: true, force: true });
-				ctx.ui.notify(`Cleared preview cache: ${CACHE_DIR}`, "info");
+				ctx.ui.notify(t("notify.cacheCleared", `Cleared preview cache: ${CACHE_DIR}`, { path: CACHE_DIR }), "info");
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				ctx.ui.notify(`Failed to clear preview cache: ${message}`, "error");
+				ctx.ui.notify(t("notify.cacheClearFailed", `Failed to clear preview cache: ${message}`, { message }), "error");
 			}
 		},
 	});


### PR DESCRIPTION
I found a small UX issue in the preview flow: the command descriptions and failure/status messages appear exactly when users choose terminal vs browser vs PDF output, pick an assistant response, or debug missing browser/LaTeX/PDF setup.

This PR makes that surface optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es — broad docs/Markdown workflow audiences
- Focused on command descriptions, picker title/controls, loader/status, browser/PDF/cache notifications

Validation:
- npm install --ignore-scripts
- npm run typecheck
- npm run check:readme-commands
- npm pack --dry-run