### PR TITLE
Localize preview overlay status text

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,72 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"preview.overlay.title": "Vista previa de Markdown",
+		"preview.overlay.pageControl": "←/→ página",
+		"preview.overlay.close": "cerrar",
+		"preview.overlay.refresh": "r actualizar",
+		"preview.overlay.openBrowser": "o abrir navegador",
+		"preview.overlay.openingBrowser": "Abriendo vista previa en el navegador...",
+		"preview.overlay.openedBrowser": "Vista previa abierta en el navegador.",
+		"preview.overlay.browserOpenFailed": "No se pudo abrir el navegador: {message}",
+		"preview.overlay.refreshing": "Actualizando vista previa para el tema actual...",
+		"preview.overlay.refreshed": "Actualizada (modo {mode}).",
+		"preview.overlay.refreshFailed": "No se pudo actualizar: {message}",
+	},
+	fr: {
+		"preview.overlay.title": "Aperçu Markdown",
+		"preview.overlay.pageControl": "←/→ page",
+		"preview.overlay.close": "fermer",
+		"preview.overlay.refresh": "r actualiser",
+		"preview.overlay.openBrowser": "o ouvrir le navigateur",
+		"preview.overlay.openingBrowser": "Ouverture de l’aperçu dans le navigateur...",
+		"preview.overlay.openedBrowser": "Aperçu ouvert dans le navigateur.",
+		"preview.overlay.browserOpenFailed": "Échec de l’ouverture du navigateur : {message}",
+		"preview.overlay.refreshing": "Actualisation de l’aperçu pour le thème actuel...",
+		"preview.overlay.refreshed": "Actualisé (mode {mode}).",
+		"preview.overlay.refreshFailed": "Échec de l’actualisation : {message}",
+	},
+	"pt-BR": {
+		"preview.overlay.title": "Prévia de Markdown",
+		"preview.overlay.pageControl": "←/→ página",
+		"preview.overlay.close": "fechar",
+		"preview.overlay.refresh": "r atualizar",
+		"preview.overlay.openBrowser": "o abrir navegador",
+		"preview.overlay.openingBrowser": "Abrindo prévia no navegador...",
+		"preview.overlay.openedBrowser": "Prévia aberta no navegador.",
+		"preview.overlay.browserOpenFailed": "Falha ao abrir o navegador: {message}",
+		"preview.overlay.refreshing": "Atualizando prévia para o tema atual...",
+		"preview.overlay.refreshed": "Atualizada (modo {mode}).",
+		"preview.overlay.refreshFailed": "Falha ao atualizar: {message}",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "pi-markdown-preview",
+		defaultLocale: "en",
+		locales: translations,
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const locale = api.getLocale?.();
+			if (isLocale(locale)) currentLocale = locale;
+			api.onLocaleChange?.((next) => {
+				if (isLocale(next)) currentLocale = next;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import {
 	replaceInlineAnnotationMarkers,
 	transformMarkdownOutsideFences,
 } from "./shared/annotation-scanner.js";
+import { initI18n, t } from "./i18n.js";
 
 const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
@@ -1701,12 +1702,12 @@ class MarkdownPreviewOverlay {
 	private rebuild(): void {
 		this.container.clear();
 
-		const title = `${this.theme.bold("Markdown preview")} ${this.theme.fg("dim", `(${this.pageIndex + 1}/${this.preview.pages.length})`)}`;
+		const title = `${this.theme.bold(t("preview.overlay.title", "Markdown preview"))} ${this.theme.fg("dim", `(${this.pageIndex + 1}/${this.preview.pages.length})`)}`;
 		this.container.addChild(new Text(this.theme.fg("accent", title), 0, 0));
 
 		const controls: string[] = [];
-		if (this.preview.pages.length > 1) controls.push("←/→ page");
-		controls.push(`${keyHint("tui.select.cancel", "close")}`, "r refresh", "o open browser");
+		if (this.preview.pages.length > 1) controls.push(t("preview.overlay.pageControl", "←/→ page"));
+		controls.push(`${keyHint("tui.select.cancel", t("preview.overlay.close", "close"))}`, t("preview.overlay.refresh", "r refresh"), t("preview.overlay.openBrowser", "o open browser"));
 		this.container.addChild(new Text(this.theme.fg("dim", controls.join(" • ")), 0, 0));
 
 		const page = this.currentPage();
@@ -1759,17 +1760,17 @@ class MarkdownPreviewOverlay {
 
 		if (matchesKey(data, "o") && !this.isOpeningBrowser) {
 			this.isOpeningBrowser = true;
-			this.statusLine = this.theme.fg("warning", "Opening browser preview...");
+			this.statusLine = this.theme.fg("warning", t("preview.overlay.openingBrowser", "Opening browser preview..."));
 			this.rebuild();
 			this.tui.requestRender();
 
 			void this.openInBrowser()
 				.then(() => {
-					this.statusLine = this.theme.fg("success", "Opened preview in browser.");
+					this.statusLine = this.theme.fg("success", t("preview.overlay.openedBrowser", "Opened preview in browser."));
 				})
 				.catch((error) => {
 					const message = error instanceof Error ? error.message : String(error);
-					this.statusLine = this.theme.fg("error", `Browser open failed: ${message}`);
+					this.statusLine = this.theme.fg("error", t("preview.overlay.browserOpenFailed", "Browser open failed: {message}", { message }));
 				})
 				.finally(() => {
 					this.isOpeningBrowser = false;
@@ -1781,7 +1782,7 @@ class MarkdownPreviewOverlay {
 
 		if (matchesKey(data, "r") && !this.isRefreshing) {
 			this.isRefreshing = true;
-			this.statusLine = this.theme.fg("warning", "Refreshing preview for current theme...");
+			this.statusLine = this.theme.fg("warning", t("preview.overlay.refreshing", "Refreshing preview for current theme..."));
 			this.rebuild();
 			this.tui.requestRender();
 
@@ -1790,11 +1791,11 @@ class MarkdownPreviewOverlay {
 					this.clearRenderedImages();
 					this.preview = preview;
 					this.pageIndex = Math.min(this.pageIndex, Math.max(0, preview.pages.length - 1));
-					this.statusLine = this.theme.fg("success", `Refreshed (${preview.themeMode} mode).`);
+					this.statusLine = this.theme.fg("success", t("preview.overlay.refreshed", "Refreshed ({mode} mode).", { mode: preview.themeMode }));
 				})
 				.catch((error) => {
 					const message = error instanceof Error ? error.message : String(error);
-					this.statusLine = this.theme.fg("error", `Refresh failed: ${message}`);
+					this.statusLine = this.theme.fg("error", t("preview.overlay.refreshFailed", "Refresh failed: {message}", { message }));
 				})
 				.finally(() => {
 					this.isRefreshing = false;
@@ -3615,6 +3616,7 @@ function parsePreviewArgs(args: string): { target?: PreviewTarget; pick?: boolea
 }
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	const run = async (args: string, ctx: ExtensionCommandContext) => {
 		const parsed = parsePreviewArgs(args);
 		if (parsed.help) {


### PR DESCRIPTION
This is a smaller follow-up after I retracted the earlier over-broad localization PR. I kept this one limited to the interactive preview overlay controls/status text only.\n\nWhat changed:\n- adds a tiny local i18n helper with English fallback\n- localizes overlay title, controls, browser-open status, and refresh status\n- registers an optional pi-core i18n bundle when available\n- includes es, fr, and pt-BR strings\n\nWhat did not change:\n- no required dependency\n- English remains the default/fallback\n- rendering, cache behavior, browser launch behavior, PDF output, and markdown content stay untouched\n\nValidation:\n- passed: npm run typecheck\n- passed: npm run check:regressions\n- passed: npm pack --dry-run\n\nIf useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.