### PR TITLE
Add Mermaid icon support and improve label contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Preview adapts to your pi theme. Examples with a custom theme and the built-in d
 - For terminal preview (`/preview` default): a Chromium-based browser executable (Chrome, Brave, Edge, Chromium). `puppeteer-core` is included as an extension dependency; no separate Puppeteer install is needed.
 - For terminal inline display: a terminal with image support (Ghostty, Kitty, iTerm2, WezTerm)
 - For PDF export (optional): a LaTeX engine, e.g. [TeX Live](https://tug.org/texlive/) (`brew install --cask mactex` on macOS, `apt install texlive` on Linux)
-- For Mermaid-in-PDF support (optional): Mermaid CLI (`npm install -g @mermaid-js/mermaid-cli`) and a Chromium browser accessible to Mermaid CLI
+- For Mermaid-in-PDF support (optional): Mermaid CLI (`npm install -g @mermaid-js/mermaid-cli`) and a Chromium browser accessible to Mermaid CLI. PDF icon nodes require Mermaid CLI 11.6+.
 
 ### Mermaid icons
 
@@ -63,7 +63,7 @@ flowchart LR
   class github changed
 ```
 
-The browser renderer loads icon-pack JSON lazily from unpkg only when a diagram references that prefix, so first render requires network access. It contrast-corrects icon and shape labels against their rendered backgrounds while preserving semantic hues. PDF export forwards the same packs to Mermaid CLI.
+The browser renderer loads icon-pack JSON lazily from unpkg only when a diagram references that prefix, so first render requires network access. It contrast-corrects icon and shape labels against their rendered backgrounds while preserving semantic hues. PDF export forwards the same packs to Mermaid CLI 11.6+ only when a supported icon is present.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ flowchart LR
   class github changed
 ```
 
-The browser renderer loads icon-pack JSON lazily from unpkg only when a diagram references that prefix, so first render requires network access. PDF export forwards the same packs to Mermaid CLI.
+The browser renderer loads icon-pack JSON lazily from unpkg only when a diagram references that prefix, so first render requires network access. It contrast-corrects icon and shape labels against their rendered backgrounds while preserving semantic hues. PDF export forwards the same packs to Mermaid CLI.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Preview adapts to your pi theme. Examples with a custom theme and the built-in d
 - For PDF export (optional): a LaTeX engine, e.g. [TeX Live](https://tug.org/texlive/) (`brew install --cask mactex` on macOS, `apt install texlive` on Linux)
 - For Mermaid-in-PDF support (optional): Mermaid CLI (`npm install -g @mermaid-js/mermaid-cli`) and a Chromium browser accessible to Mermaid CLI
 
+### Mermaid icons
+
+Mermaid flowcharts support optional `lucide:*` and `logos:*` icons. Keep each icon metadata declaration on one source line:
+
+```mermaid
+flowchart LR
+  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }
+  github@{ icon: "logos:github-icon", form: "rounded", label: "GitHub", pos: "b", h: 56 }
+  source -->|publish| github
+  classDef unchanged fill:#f8f9fa,stroke:#868e96,stroke-width:2px
+  classDef changed fill:#f3f0ff,stroke:#7950f2,stroke-width:2px
+  class source unchanged
+  class github changed
+```
+
+The browser renderer loads icon-pack JSON lazily from unpkg only when a diagram references that prefix, so first render requires network access. PDF export forwards the same packs to Mermaid CLI.
+
 ## Install
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
 const PREVIEW_ANNOTATION_PLACEHOLDER_PREFIX = "PIMDPREVIEWANNOT";
 const ANNOTATION_HELPERS_SOURCE = readFileSync(new URL("./client/annotation-helpers.js", import.meta.url), "utf-8");
-const RENDER_VERSION = "v22";
+const RENDER_VERSION = "v23";
 const MERMAID_BROWSER_VERSION = "11.16.0";
 const MERMAID_CLI_ICON_PACKS = ["@iconify-json/lucide", "@iconify-json/logos"] as const;
 const MERMAID_BROWSER_ICON_PACKS = [
@@ -3166,12 +3166,62 @@ export function buildMermaidBrowserModule(mermaidConfigJson: string, mermaidIcon
           pre.replaceWith(wrapper);
         });
         await mermaid.run();
+        const parseRgb = (value) => {
+          const match = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/);
+          return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+        };
+        const relativeLuminance = (color) => {
+          const linear = color.map((channel) => {
+            const value = channel / 255;
+            return value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+          });
+          return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+        };
+        const contrastRatio = (foreground, background) => {
+          const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+          const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+          return (lighter + 0.05) / (darker + 0.05);
+        };
+        const toRgb = (color) => 'rgb(' + color.map((channel) => Math.round(channel)).join(', ') + ')';
+        const ensureReadableColor = (foregroundCss, backgroundCss) => {
+          const foreground = parseRgb(foregroundCss);
+          const background = parseRgb(backgroundCss);
+          if (!foreground || !background || contrastRatio(foreground, background) >= 4.5) return foregroundCss;
+          const readableCandidates = [[0, 0, 0], [255, 255, 255]].flatMap((target) => {
+            for (let step = 1; step <= 20; step += 1) {
+              const amount = step / 20;
+              const color = foreground.map((channel, index) => channel + (target[index] - channel) * amount);
+              if (contrastRatio(color, background) >= 4.5) return [{ amount, color }];
+            }
+            return [];
+          });
+          readableCandidates.sort((left, right) => left.amount - right.amount);
+          if (readableCandidates.length > 0) return toRgb(readableCandidates[0].color);
+          const black = [0, 0, 0];
+          const white = [255, 255, 255];
+          return toRgb(contrastRatio(black, background) >= contrastRatio(white, background) ? black : white);
+        };
+        const pageBackground = getComputedStyle(document.body).backgroundColor;
         document.querySelectorAll('.mermaid-container .icon-shape').forEach((node) => {
           const icon = node.querySelector('svg');
           if (!icon) return;
-          const iconColor = getComputedStyle(icon).color;
+          const iconColor = ensureReadableColor(getComputedStyle(icon).color, pageBackground);
+          icon.style.setProperty('color', iconColor, 'important');
           node.querySelectorAll('.labelBkg, .nodeLabel').forEach((label) => {
             if (label instanceof HTMLElement) label.style.setProperty('color', iconColor, 'important');
+          });
+        });
+        document.querySelectorAll('.mermaid-container .node:not(.icon-shape)').forEach((node) => {
+          const shape = Array.from(node.querySelectorAll('rect, polygon, path, circle, ellipse')).find((candidate) => {
+            const fill = getComputedStyle(candidate).fill;
+            return fill && fill !== 'none' && fill !== 'rgba(0, 0, 0, 0)';
+          });
+          if (!shape) return;
+          const shapeFill = getComputedStyle(shape).fill;
+          node.querySelectorAll('.nodeLabel').forEach((label) => {
+            if (!(label instanceof HTMLElement)) return;
+            const labelColor = ensureReadableColor(getComputedStyle(label).color, shapeFill);
+            label.style.setProperty('color', labelColor, 'important');
           });
         });
       } catch (error) {

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,17 @@ const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
 const PREVIEW_ANNOTATION_PLACEHOLDER_PREFIX = "PIMDPREVIEWANNOT";
 const ANNOTATION_HELPERS_SOURCE = readFileSync(new URL("./client/annotation-helpers.js", import.meta.url), "utf-8");
-const RENDER_VERSION = "v21";
+const RENDER_VERSION = "v22";
+const MERMAID_BROWSER_VERSION = "11.16.0";
+const MERMAID_CLI_ICON_PACKS = ["@iconify-json/lucide", "@iconify-json/logos"] as const;
+const MERMAID_BROWSER_ICON_PACKS = [
+	{ name: "lucide", url: "https://unpkg.com/@iconify-json/lucide@1/icons.json" },
+	{ name: "logos", url: "https://unpkg.com/@iconify-json/logos@1/icons.json" },
+] as const;
+const PI_MERMAID_CLI_PATH = join(
+	homedir(), ".pi", "agent", "npm", "node_modules", ".bin",
+	process.platform === "win32" ? "mmdc.cmd" : "mmdc",
+);
 const DEFAULT_TERMINAL_PREVIEW_FONT_SIZE_PX = 16;
 const DEFAULT_BROWSER_PREVIEW_FONT_SIZE_PX = 15;
 const MIN_PREVIEW_FONT_SIZE_PX = 10;
@@ -1597,7 +1607,7 @@ let sharedPreviewBrowser: puppeteer.Browser | undefined;
 let sharedPreviewBrowserLaunchPromise: Promise<puppeteer.Browser> | undefined;
 let sharedPreviewBrowserLaunchToken = 0;
 
-async function launchPreviewBrowser(): Promise<puppeteer.Browser> {
+export function getPreviewBrowserLaunchOptions(): { executablePath: string; args: string[] } {
 	const executablePath = findBrowserExecutable();
 	if (!executablePath) {
 		throw new Error(
@@ -1606,11 +1616,12 @@ async function launchPreviewBrowser(): Promise<puppeteer.Browser> {
 	}
 
 	const args = ["--disable-gpu", "--font-render-hinting=medium"];
-	if (process.platform === "linux") {
-		args.push("--no-sandbox", "--disable-setuid-sandbox");
-	}
+	if (process.platform === "linux") args.push("--no-sandbox", "--disable-setuid-sandbox");
+	return { executablePath, args };
+}
 
-	return puppeteer.launch({ headless: true, executablePath, args });
+async function launchPreviewBrowser(): Promise<puppeteer.Browser> {
+	return puppeteer.launch({ headless: true, ...getPreviewBrowserLaunchOptions() });
 }
 
 async function getSharedPreviewBrowser(): Promise<puppeteer.Browser> {
@@ -2819,8 +2830,13 @@ function getMermaidPdfTheme(): "default" | "forest" | "dark" | "neutral" {
 	return "default";
 }
 
+function getMermaidCliCommand(): string {
+	return process.env.MERMAID_CLI_PATH?.trim()
+		|| (existsSync(PI_MERMAID_CLI_PATH) ? PI_MERMAID_CLI_PATH : "mmdc");
+}
+
 async function renderMermaidDiagramForPdf(source: string, outputPath: string): Promise<void> {
-	const mermaidCommand = process.env.MERMAID_CLI_PATH?.trim() || "mmdc";
+	const mermaidCommand = getMermaidCliCommand();
 	const mermaidTheme = getMermaidPdfTheme();
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-markdown-preview-mermaid-"));
 	const inputPath = join(tempDir, "diagram.mmd");
@@ -2830,7 +2846,7 @@ async function renderMermaidDiagramForPdf(source: string, outputPath: string): P
 	try {
 		await writeFile(inputPath, source, "utf-8");
 		await new Promise<void>((resolve, reject) => {
-			const args = ["-i", inputPath, "-o", outputPath, "-t", mermaidTheme, "-f"];
+			const args = ["-i", inputPath, "-o", outputPath, "-t", mermaidTheme, "-f", "--iconPacks", ...MERMAID_CLI_ICON_PACKS];
 			const child = spawn(mermaidCommand, args, { stdio: ["ignore", "ignore", "pipe"] });
 			const stderrChunks: Buffer[] = [];
 			let settled = false;
@@ -3117,6 +3133,54 @@ function buildPreviewCssVars(style: PreviewStyle, fontSizePx?: number): Record<s
 	};
 }
 
+export function buildMermaidBrowserModule(mermaidConfigJson: string, mermaidIconPacksJson: string): string {
+	return String.raw`
+    const renderMermaid = async () => {
+      const mermaidBlocks = document.querySelectorAll('pre.mermaid');
+      if (mermaidBlocks.length === 0) return;
+
+      try {
+        const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_BROWSER_VERSION}/dist/mermaid.esm.min.mjs');
+        const packs = ${mermaidIconPacksJson};
+        const pending = new Map();
+        const load = (pack) => {
+          if (!pending.has(pack.name)) {
+            pending.set(pack.name, fetch(pack.url).then((response) => {
+              if (!response.ok) throw new Error('Failed to load Mermaid icon pack ' + pack.name + ': HTTP ' + response.status);
+              return response.json();
+            }));
+          }
+          return pending.get(pack.name);
+        };
+        mermaid.registerIconPacks(packs.map((pack) => ({ name: pack.name, loader: () => load(pack) })));
+        mermaid.initialize(${mermaidConfigJson});
+        mermaidBlocks.forEach((pre) => {
+          const code = pre.querySelector('code');
+          const src = code ? code.textContent : pre.textContent;
+          const wrapper = document.createElement('div');
+          wrapper.className = 'mermaid-container';
+          const div = document.createElement('div');
+          div.className = 'mermaid';
+          div.textContent = src;
+          wrapper.appendChild(div);
+          pre.replaceWith(wrapper);
+        });
+        await mermaid.run();
+        document.querySelectorAll('.mermaid-container .icon-shape').forEach((node) => {
+          const icon = node.querySelector('svg');
+          if (!icon) return;
+          const iconColor = getComputedStyle(icon).color;
+          node.querySelectorAll('.labelBkg, .nodeLabel').forEach((label) => {
+            if (label instanceof HTMLElement) label.style.setProperty('color', iconColor, 'important');
+          });
+        });
+      } catch (error) {
+        console.error('Mermaid render failed:', error);
+      }
+    };
+  `;
+}
+
 function buildBrowserHtmlFromPandocFragment(
 	fragmentHtml: string,
 	style: PreviewStyle,
@@ -3150,6 +3214,7 @@ function buildBrowserHtmlFromPandocFragment(
 		},
 	};
 	const mermaidConfigJson = JSON.stringify(mermaidConfig).replace(/</g, "\\u003c");
+	const mermaidIconPacksJson = JSON.stringify(MERMAID_BROWSER_ICON_PACKS).replace(/</g, "\\u003c");
 	const baseTag = resourcePath ? `\n<base href="${pathToFileURL(resourcePath + "/").href}" />` : "";
 	const annotationHelpersScript = ANNOTATION_HELPERS_SOURCE.replace(/<\/script/gi, "<\\/script");
 	const annotationPlaceholdersJson = JSON.stringify(annotationPlaceholders).replace(/</g, "\\u003c");
@@ -3719,29 +3784,7 @@ ${annotationHelpersScript}
       }
     };
 
-    const renderMermaid = async () => {
-      const mermaidBlocks = document.querySelectorAll('pre.mermaid');
-      if (mermaidBlocks.length === 0) return;
-
-      try {
-        const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs');
-        mermaid.initialize(${mermaidConfigJson});
-        mermaidBlocks.forEach(pre => {
-          const code = pre.querySelector('code');
-          const src = code ? code.textContent : pre.textContent;
-          const wrapper = document.createElement('div');
-          wrapper.className = 'mermaid-container';
-          const div = document.createElement('div');
-          div.className = 'mermaid';
-          div.textContent = src;
-          wrapper.appendChild(div);
-          pre.replaceWith(wrapper);
-        });
-        await mermaid.run();
-      } catch (e) {
-        console.error('Mermaid render failed:', e);
-      }
-    };
+${buildMermaidBrowserModule(mermaidConfigJson, mermaidIconPacksJson)}
 
     const root = document.getElementById('preview-root');
     try {

--- a/index.ts
+++ b/index.ts
@@ -2856,6 +2856,10 @@ function getMermaidCliCommand(): string {
 		|| (existsSync(PI_MERMAID_CLI_PATH) ? PI_MERMAID_CLI_PATH : "mmdc");
 }
 
+function usesSupportedMermaidIconPack(source: string): boolean {
+	return /@\{[^\r\n}]*\bicon\s*:\s*["'](?:lucide|logos):/.test(source);
+}
+
 async function renderMermaidDiagramForPdf(source: string, outputPath: string): Promise<void> {
 	const mermaidCommand = getMermaidCliCommand();
 	const mermaidTheme = getMermaidPdfTheme();
@@ -2867,7 +2871,10 @@ async function renderMermaidDiagramForPdf(source: string, outputPath: string): P
 	try {
 		await writeFile(inputPath, source, "utf-8");
 		await new Promise<void>((resolve, reject) => {
-			const args = ["-i", inputPath, "-o", outputPath, "-t", mermaidTheme, "-f", "--iconPacks", ...MERMAID_CLI_ICON_PACKS];
+			const args = ["-i", inputPath, "-o", outputPath, "-t", mermaidTheme, "-f"];
+			if (usesSupportedMermaidIconPack(source)) {
+				args.push("--iconPacks", ...MERMAID_CLI_ICON_PACKS);
+			}
 			const child = spawn(mermaidCommand, args, { stdio: ["ignore", "ignore", "pipe"] });
 			const stderrChunks: Buffer[] = [];
 			let settled = false;

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
 const PREVIEW_ANNOTATION_PLACEHOLDER_PREFIX = "PIMDPREVIEWANNOT";
 const ANNOTATION_HELPERS_SOURCE = readFileSync(new URL("./client/annotation-helpers.js", import.meta.url), "utf-8");
-const RENDER_VERSION = "v23";
+const RENDER_VERSION = "v25";
 const MERMAID_BROWSER_VERSION = "11.16.0";
 const MERMAID_CLI_ICON_PACKS = ["@iconify-json/lucide", "@iconify-json/logos"] as const;
 const MERMAID_BROWSER_ICON_PACKS = [
@@ -135,6 +135,15 @@ interface RenderPreviewResult {
 	pages: PreviewPage[];
 	themeMode: ThemeMode;
 	truncatedPages: boolean;
+}
+interface BrowserMermaidRenderResult {
+	status: "pending" | "skipped" | "success" | "failed";
+	error?: string;
+}
+
+function throwIfMermaidRenderFailed(mermaidResult: BrowserMermaidRenderResult | null): void {
+	if (mermaidResult?.status !== "failed") return;
+	throw new Error(`Mermaid render failed: ${mermaidResult.error?.trim() || "Unknown browser error."}`);
 }
 
 interface CachedPage {
@@ -1804,8 +1813,12 @@ async function renderPreview(markdown: string, style: PreviewStyle, signal?: Abo
 			await waitForPageRenderReady(browserPage!);
 			await browserPage!.waitForFunction(
 				"window.__mermaidDone === true",
-				{ timeout: 15000 }
-			).catch(() => {});
+				{ timeout: 15000 },
+			);
+			const mermaidResult = await browserPage!.evaluate(() => (
+				(window as Window & { __mermaidRenderResult?: BrowserMermaidRenderResult }).__mermaidRenderResult ?? null
+			));
+			throwIfMermaidRenderFailed(mermaidResult);
 		};
 
 		// First pass: measure content height.
@@ -3135,40 +3148,86 @@ function buildPreviewCssVars(style: PreviewStyle, fontSizePx?: number): Record<s
 
 export function buildMermaidBrowserModule(mermaidConfigJson: string, mermaidIconPacksJson: string): string {
 	return String.raw`
+    const setMermaidRenderResult = (status, error) => {
+      window.__mermaidRenderResult = error ? { status, error } : { status };
+    };
+    const renderMermaidFailure = (wrappers, message) => {
+      wrappers.forEach((wrapper) => {
+        const failure = document.createElement('pre');
+        failure.className = 'mermaid-error';
+        failure.setAttribute('role', 'alert');
+        failure.style.cssText = 'margin:0;padding:12px 14px;border:1px solid var(--error,#cf222e);border-radius:8px;background:var(--panel-2,#f8fafc);color:var(--error,#cf222e);text-align:left;white-space:pre-wrap;overflow-wrap:anywhere;';
+        failure.textContent = 'Mermaid render failed: ' + message;
+        wrapper.replaceChildren(failure);
+      });
+    };
     const renderMermaid = async () => {
       const mermaidBlocks = document.querySelectorAll('pre.mermaid');
-      if (mermaidBlocks.length === 0) return;
+      if (mermaidBlocks.length === 0) {
+        setMermaidRenderResult('skipped');
+        return;
+      }
+
+      setMermaidRenderResult('pending');
+      const wrappers = Array.from(mermaidBlocks).map((pre) => {
+        const code = pre.querySelector('code');
+        const src = code ? code.textContent : pre.textContent;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'mermaid-container';
+        const div = document.createElement('div');
+        div.className = 'mermaid';
+        div.textContent = src;
+        wrapper.appendChild(div);
+        pre.replaceWith(wrapper);
+        return wrapper;
+      });
 
       try {
         const { default: mermaid } = await import('https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_BROWSER_VERSION}/dist/mermaid.esm.min.mjs');
         const packs = ${mermaidIconPacksJson};
         const pending = new Map();
+        let iconPackError = null;
         const load = (pack) => {
           if (!pending.has(pack.name)) {
             pending.set(pack.name, fetch(pack.url).then((response) => {
               if (!response.ok) throw new Error('Failed to load Mermaid icon pack ' + pack.name + ': HTTP ' + response.status);
               return response.json();
+            }).catch((error) => {
+              iconPackError ??= error instanceof Error ? error : new Error(String(error));
+              throw error;
             }));
           }
           return pending.get(pack.name);
         };
         mermaid.registerIconPacks(packs.map((pack) => ({ name: pack.name, loader: () => load(pack) })));
         mermaid.initialize(${mermaidConfigJson});
-        mermaidBlocks.forEach((pre) => {
-          const code = pre.querySelector('code');
-          const src = code ? code.textContent : pre.textContent;
-          const wrapper = document.createElement('div');
-          wrapper.className = 'mermaid-container';
-          const div = document.createElement('div');
-          div.className = 'mermaid';
-          div.textContent = src;
-          wrapper.appendChild(div);
-          pre.replaceWith(wrapper);
-        });
         await mermaid.run();
+        if (iconPackError) throw iconPackError;
         const parseRgb = (value) => {
           const match = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/);
           return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : null;
+        };
+        const isOpaqueColor = (value) => {
+          if (!parseRgb(value)) return false;
+          const alphaMatch = value.match(/^rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/);
+          return !alphaMatch || Number(alphaMatch[1]) >= 1;
+        };
+        const findOpaqueFill = (root) => {
+          if (!(root instanceof Element)) return null;
+          const shape = Array.from(root.querySelectorAll('rect, polygon, path, circle, ellipse')).find((candidate) => {
+            const fill = getComputedStyle(candidate).fill;
+            return isOpaqueColor(fill);
+          });
+          return shape ? getComputedStyle(shape).fill : null;
+        };
+        const findOpaqueBackground = (element, fallback) => {
+          let current = element instanceof Element ? element : null;
+          while (current) {
+            const background = getComputedStyle(current).backgroundColor;
+            if (current instanceof HTMLElement && isOpaqueColor(background)) return background;
+            current = current.parentElement;
+          }
+          return fallback;
         };
         const relativeLuminance = (color) => {
           const linear = color.map((channel) => {
@@ -3205,10 +3264,16 @@ export function buildMermaidBrowserModule(mermaidConfigJson: string, mermaidIcon
         document.querySelectorAll('.mermaid-container .icon-shape').forEach((node) => {
           const icon = node.querySelector('svg');
           if (!icon) return;
-          const iconColor = ensureReadableColor(getComputedStyle(icon).color, pageBackground);
+          const semanticColor = getComputedStyle(icon).color;
+          const iconSurface = findOpaqueFill(node.firstElementChild)
+            || findOpaqueBackground(icon, pageBackground);
+          const iconColor = ensureReadableColor(semanticColor, iconSurface);
           icon.style.setProperty('color', iconColor, 'important');
           node.querySelectorAll('.labelBkg, .nodeLabel').forEach((label) => {
-            if (label instanceof HTMLElement) label.style.setProperty('color', iconColor, 'important');
+            if (!(label instanceof HTMLElement)) return;
+            const labelSurface = findOpaqueBackground(label, pageBackground);
+            const labelColor = ensureReadableColor(semanticColor, labelSurface);
+            label.style.setProperty('color', labelColor, 'important');
           });
         });
         document.querySelectorAll('.mermaid-container .node:not(.icon-shape)').forEach((node) => {
@@ -3224,7 +3289,11 @@ export function buildMermaidBrowserModule(mermaidConfigJson: string, mermaidIcon
             label.style.setProperty('color', labelColor, 'important');
           });
         });
+        setMermaidRenderResult('success');
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setMermaidRenderResult('failed', message);
+        renderMermaidFailure(wrappers, message);
         console.error('Mermaid render failed:', error);
       }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
       "devDependencies": {
         "@earendil-works/pi-coding-agent": "^0.81.1",
         "@earendil-works/pi-tui": "^0.81.1",
+        "@iconify-json/logos": "1.2.11",
+        "@iconify-json/lucide": "1.2.120",
         "@types/node": "^24.3.0",
+        "mermaid": "11.16.0",
         "typebox": "^1.1.39",
         "typescript": "^5.7.3"
       },
@@ -23,6 +26,34 @@
         "@earendil-works/pi-tui": "*",
         "typebox": "*"
       }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@earendil-works/pi-coding-agent": {
       "version": "0.81.1",
@@ -1996,6 +2027,55 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@iconify-json/logos": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@iconify-json/logos/-/logos-1.2.11.tgz",
+      "integrity": "sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/lucide": {
+      "version": "1.2.120",
+      "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.120.tgz",
+      "integrity": "sha512-4ECF24fxag1n5tZlPGrbWuCGqhkwD0rvAzfCXretqQb4KEC8Y6ja3khF8qmvpR1Mk0NQDhBTRK3Fr/YoV8QyJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.1.tgz",
@@ -2023,6 +2103,297 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
@@ -2033,6 +2404,14 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -2041,6 +2420,17 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/agent-base": {
@@ -2256,6 +2646,567 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -2264,6 +3215,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2296,11 +3254,31 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1566079",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2316,6 +3294,18 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2473,6 +3463,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -2499,6 +3496,40 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -2517,6 +3548,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -2530,6 +3608,49 @@
       "version": "18.0.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
       "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2601,11 +3722,43 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -2677,6 +3830,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -2775,6 +3962,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -2807,6 +4001,26 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -2848,6 +4062,20 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.81.1",
     "@earendil-works/pi-tui": "^0.81.1",
+    "@iconify-json/logos": "1.2.11",
+    "@iconify-json/lucide": "1.2.120",
     "@types/node": "^24.3.0",
+    "mermaid": "11.16.0",
     "typebox": "^1.1.39",
     "typescript": "^5.7.3"
   }

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -288,27 +288,40 @@ assert.equal(
 );
 
 const transpiledIndexPath = resolve(process.cwd(), `.pi-markdown-preview-registration-test-${process.pid}.mjs`);
-const transpiledIndex = ts.transpileModule(src, {
+const transpiledIndexOutput = ts.transpileModule(src, {
 	compilerOptions: {
 		module: ts.ModuleKind.ES2022,
 		target: ts.ScriptTarget.ES2022,
 	},
 	fileName: sourcePath,
 }).outputText;
+const transpiledIndex = transpiledIndexOutput.replace(
+	"function throwIfMermaidRenderFailed(mermaidResult) {",
+	"export function throwIfMermaidRenderFailed(mermaidResult) {",
+);
+assert.notEqual(transpiledIndex, transpiledIndexOutput, "Regression harness should expose the production Mermaid failure guard only in transpiled test output.");
 
 let extensionFactory;
 let buildMermaidBrowserModule;
 let getPreviewBrowserLaunchOptions;
+let throwIfMermaidRenderFailed;
 try {
 	await writeFile(transpiledIndexPath, transpiledIndex, "utf8");
-	({ default: extensionFactory, buildMermaidBrowserModule, getPreviewBrowserLaunchOptions } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
+	({ default: extensionFactory, buildMermaidBrowserModule, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
 } finally {
 	await rm(transpiledIndexPath, { force: true });
 }
 
-assert.match(src, /const RENDER_VERSION = "v23";/, "Mermaid contrast renderer should invalidate stale preview cache entries.");
+assert.match(src, /const RENDER_VERSION = "v25";/, "Observable Mermaid failures should advance beyond the Slice 1 cache epoch.");
 assert.match(src, /const MERMAID_BROWSER_VERSION = "11\.16\.0";/, "Browser Mermaid version should match the CLI validator.");
 assert.match(src, /"--iconPacks", \.\.\.MERMAID_CLI_ICON_PACKS/, "PDF Mermaid rendering should forward both icon packs.");
+assert.ok(src.includes("const mermaidResult = await browserPage!.evaluate"), "Puppeteer rendering should read structured Mermaid status.");
+assert.ok(src.includes("throwIfMermaidRenderFailed(mermaidResult);"), "Puppeteer rendering should invoke the production Mermaid failure guard.");
+assert.doesNotMatch(
+	src,
+	/window\.__mermaidDone === true"[\s\S]{0,100}\.catch\(\(\) => \{\}\)/,
+	"Puppeteer rendering should not discard Mermaid readiness timeouts.",
+);
 
 const parseRgb = (value) => {
 	const channels = value.match(/[\d.]+/g)?.slice(0, 3).map(Number);
@@ -328,25 +341,26 @@ const contrastRatio = (foreground, background) => {
 	return (lighter + 0.05) / (darker + 0.05);
 };
 
-async function assertMermaidIconBrowserRendering(theme) {
+const mermaidIconFixture = [
+	"flowchart LR",
+	'  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }',
+	'  payload@{ shape: "doc", label: "Payload" }',
+	'  store@{ shape: "cyl", label: "Store" }',
+	'  midtone@{ shape: "rounded", label: "Midtone" }',
+	'  github@{ icon: "logos:github-icon", form: "rounded", label: "GitHub", pos: "b", h: 56 }',
+	"  source -->|prepare| payload -->|persist| store -->|review| midtone -->|publish| github",
+	"  classDef unchanged fill:#f8f9fa,stroke:#868e96,stroke-width:2px",
+	"  classDef changed fill:#f3f0ff,stroke:#7950f2,stroke-width:2px",
+	"  classDef midtone fill:#808080,stroke:#666666,stroke-width:2px",
+	"  class source,store unchanged",
+	"  class payload,github changed",
+	"  class midtone midtone",
+].join("\n");
+
+async function renderMermaidBrowserFixture(theme, fixture, options = {}) {
 	const palette = theme === "dark"
 		? { background: "#0f1117", surface: "#171b24", text: "#e6edf3", line: "#9aa5b1" }
 		: { background: "#f5f7fb", surface: "#ffffff", text: "#1f2328", line: "#57606a" };
-	const fixture = [
-		"flowchart LR",
-		'  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }',
-		'  payload@{ shape: "doc", label: "Payload" }',
-		'  store@{ shape: "cyl", label: "Store" }',
-		'  midtone@{ shape: "rounded", label: "Midtone" }',
-		'  github@{ icon: "logos:github-icon", form: "rounded", label: "GitHub", pos: "b", h: 56 }',
-		"  source -->|prepare| payload -->|persist| store -->|review| midtone -->|publish| github",
-		"  classDef unchanged fill:#f8f9fa,stroke:#868e96,stroke-width:2px",
-		"  classDef changed fill:#f3f0ff,stroke:#7950f2,stroke-width:2px",
-		"  classDef midtone fill:#808080,stroke:#666666,stroke-width:2px",
-		"  class source,store unchanged",
-		"  class payload,github changed",
-		"  class midtone midtone",
-	].join("\n");
 	const mermaidConfig = {
 		startOnLoad: false,
 		theme: "base",
@@ -382,6 +396,15 @@ async function assertMermaidIconBrowserRendering(theme) {
 				? resolve(fixtureRoot, "mermaid", url.pathname.slice("/npm/mermaid@11.16.0/".length))
 				: undefined;
 			const iconFixture = url.hostname === "unpkg.com" ? iconFixtures.get(url.pathname) : undefined;
+			if (iconFixture && options.failIconPack === iconFixture.name) {
+				servedFixtures.add(`failed:${iconFixture.name}`);
+				return request.respond({
+					status: 503,
+					body: JSON.stringify({ error: "fixture unavailable" }),
+					contentType: "application/json",
+					headers: { "access-control-allow-origin": "*" },
+				});
+			}
 			const localPath = mermaidFixture ?? iconFixture?.path;
 			if (!localPath) {
 				if (url.hostname === "cdn.jsdelivr.net" || url.hostname === "unpkg.com") return request.abort("blockedbyclient");
@@ -401,60 +424,167 @@ async function assertMermaidIconBrowserRendering(theme) {
 				{ name: "logos", url: "https://unpkg.com/@iconify-json/logos@1/icons.json" },
 			]),
 		);
-		await page.setContent(`<!doctype html><body style="background:${palette.background};color:${palette.text}"><pre class="mermaid"><code>${fixture}</code></pre><script type="module">${browserModule}\n(async () => { try { await renderMermaid(); } finally { window.__mermaidDone = true; } })();</script></body>`, { waitUntil: "domcontentloaded" });
+		await page.setContent(`<!doctype html><body style="background:${palette.background};color:${palette.text}"><div id="preview-root" style="background:${palette.surface}"><pre class="mermaid"><code>${fixture}</code></pre></div><script type="module">${browserModule}\n(async () => { try { await renderMermaid(); } finally { window.__mermaidDone = true; } })();</script></body>`, { waitUntil: "domcontentloaded" });
 		await page.waitForFunction(() => window.__mermaidDone === true, { timeout: 30000 });
-		const result = await page.evaluate(() => ({
-			iconCount: document.querySelectorAll(".icon-shape svg").length,
-			edgeColor: getComputedStyle(document.querySelector(".edgeLabel")).color,
-			bodyColor: getComputedStyle(document.body).color,
-			bodyBackground: getComputedStyle(document.body).backgroundColor,
-			iconNodes: Array.from(document.querySelectorAll(".icon-shape")).map((node) => {
-				const label = node.querySelector(".nodeLabel");
-				const icon = node.querySelector("svg");
-				return {
-					label: label?.textContent?.trim(),
-					labelColor: getComputedStyle(label).color,
-					iconColor: getComputedStyle(icon).color,
-					hasPath: Boolean(icon?.querySelector("path")),
-				};
-			}),
-			shapeNodes: Array.from(document.querySelectorAll(".node:not(.icon-shape)")).map((node) => {
-				const label = node.querySelector(".nodeLabel");
-				const shape = Array.from(node.querySelectorAll("rect, polygon, path, circle, ellipse")).find((candidate) => {
-					const fill = getComputedStyle(candidate).fill;
-					return fill && fill !== "none" && fill !== "rgba(0, 0, 0, 0)";
-				});
-				return {
-					label: label?.textContent?.trim(),
-					labelColor: getComputedStyle(label).color,
-					shapeFill: getComputedStyle(shape).fill,
-				};
-			}),
-		}));
-		assert.ok(result.iconCount >= 2, `${theme} icon rendering should render icon SVGs rather than placeholders.`);
-		assert.deepEqual(result.iconNodes.map(({ label }) => label), ["Source", "GitHub"]);
-		assert.ok(result.iconNodes.every((node) => node.hasPath), `${theme} icon nodes should contain rendered SVG paths.`);
-		assert.deepEqual(result.shapeNodes.map(({ label }) => label), ["Payload", "Store", "Midtone"]);
-		assert.deepEqual(servedFixtures, new Set(["mermaid", "lucide", "logos"]), `${theme} fixture rendering should not use the network.`);
-		for (const node of result.iconNodes) {
-			assert.equal(node.labelColor, node.iconColor, `${theme} icon label should inherit its icon color.`);
-			assert.ok(contrastRatio(node.labelColor, result.bodyBackground) >= 4.5, `${theme} icon labels should meet accessible contrast.`);
-		}
-		for (const node of result.shapeNodes) {
-			assert.ok(contrastRatio(node.labelColor, node.shapeFill) >= 4.5, `${theme} shape labels should meet accessible contrast.`);
-		}
-		assert.equal(result.edgeColor, result.bodyColor, `${theme} edge labels should retain theme text color.`);
-		assert.ok(result.iconNodes.some((node) => node.labelColor !== result.edgeColor), `${theme} icon labels should remain semantically colored.`);
-		assert.notEqual(result.iconNodes[0]?.iconColor, result.iconNodes[1]?.iconColor, `${theme} gray and violet attribution icons should remain distinct.`);
-		assert.deepEqual(consoleErrors, [], `${theme} Mermaid rendering should not log console errors.`);
+		const result = await page.evaluate(() => {
+			const isOpaqueColor = (value) => {
+				const match = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/);
+				if (!match) return false;
+				const alphaMatch = value.match(/^rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)$/);
+				return !alphaMatch || Number(alphaMatch[1]) >= 1;
+			};
+			const findOpaqueFill = (root) => {
+				if (!(root instanceof Element)) return "";
+				const shape = Array.from(root.querySelectorAll("rect, polygon, path, circle, ellipse")).find((candidate) => (
+					isOpaqueColor(getComputedStyle(candidate).fill)
+				));
+				return shape ? getComputedStyle(shape).fill : "";
+			};
+			const findOpaqueBackground = (element) => {
+				let current = element instanceof Element ? element : null;
+				while (current) {
+					const background = getComputedStyle(current).backgroundColor;
+					if (current instanceof HTMLElement && isOpaqueColor(background)) return background;
+					current = current.parentElement;
+				}
+				return getComputedStyle(document.body).backgroundColor;
+			};
+			const edgeLabel = document.querySelector(".edgeLabel");
+			const failure = document.querySelector(".mermaid-error");
+			return {
+				mermaidRenderResult: window.__mermaidRenderResult ?? null,
+				failurePanel: failure ? { role: failure.getAttribute("role"), text: failure.textContent?.trim() } : null,
+				iconCount: document.querySelectorAll(".icon-shape svg").length,
+				edgeColor: edgeLabel ? getComputedStyle(edgeLabel).color : "",
+				bodyColor: getComputedStyle(document.body).color,
+				bodyBackground: getComputedStyle(document.body).backgroundColor,
+				previewRootBackground: getComputedStyle(document.querySelector("#preview-root")).backgroundColor,
+				iconNodes: Array.from(document.querySelectorAll(".icon-shape")).map((node) => {
+					const label = node.querySelector(".nodeLabel");
+					const icon = node.querySelector("svg");
+					return {
+						label: label?.textContent?.trim(),
+						labelColor: label ? getComputedStyle(label).color : "",
+						labelSurface: findOpaqueBackground(label),
+						iconColor: icon ? getComputedStyle(icon).color : "",
+						iconSurfaceFill: findOpaqueFill(node.firstElementChild),
+						hasPath: Boolean(icon?.querySelector("path")),
+					};
+				}),
+				shapeNodes: Array.from(document.querySelectorAll(".node:not(.icon-shape)")).map((node) => {
+					const label = node.querySelector(".nodeLabel");
+					const shape = Array.from(node.querySelectorAll("rect, polygon, path, circle, ellipse")).find((candidate) => {
+						const fill = getComputedStyle(candidate).fill;
+						return fill && fill !== "none" && fill !== "rgba(0, 0, 0, 0)";
+					});
+					return {
+						label: label?.textContent?.trim(),
+						labelColor: label ? getComputedStyle(label).color : "",
+						shapeFill: shape ? getComputedStyle(shape).fill : "",
+					};
+				}),
+			};
+		});
+		return { result, consoleErrors, servedFixtures };
 	} finally {
 		await browser.close();
 	}
 }
 
-await assertMermaidIconBrowserRendering("dark");
-await assertMermaidIconBrowserRendering("light");
+async function assertMermaidIconBrowserRendering(theme) {
+	const { result, consoleErrors, servedFixtures } = await renderMermaidBrowserFixture(theme, mermaidIconFixture);
+	assert.deepEqual(result.mermaidRenderResult, { status: "success" }, `${theme} Mermaid fixture should report successful rendering.`);
+	assert.equal(result.failurePanel, null, `${theme} successful Mermaid rendering should not show a failure panel.`);
+	assert.ok(result.iconCount >= 2, `${theme} icon rendering should render icon SVGs rather than placeholders.`);
+	assert.deepEqual(result.iconNodes.map(({ label }) => label), ["Source", "GitHub"]);
+	assert.ok(result.iconNodes.every((node) => node.hasPath), `${theme} icon nodes should contain rendered SVG paths.`);
+	assert.deepEqual(result.shapeNodes.map(({ label }) => label), ["Payload", "Store", "Midtone"]);
+	assert.deepEqual(servedFixtures, new Set(["mermaid", "lucide", "logos"]), `${theme} fixture rendering should not use the network.`);
+	for (const node of result.iconNodes) {
+		assert.ok(contrastRatio(node.iconColor, node.iconSurfaceFill) >= 4.5, `${theme} icon glyphs should meet accessible contrast against their rendered shapes.`);
+		assert.ok(contrastRatio(node.labelColor, node.labelSurface) >= 4.5, `${theme} icon labels should meet accessible contrast against their rendered backgrounds.`);
+	}
+	for (const node of result.shapeNodes) {
+		assert.ok(contrastRatio(node.labelColor, node.shapeFill) >= 4.5, `${theme} shape labels should meet accessible contrast.`);
+	}
+	assert.ok(result.iconNodes.every((node) => node.iconSurfaceFill !== result.bodyBackground), `${theme} icon fixture shapes should differ from the page background.`);
+	assert.notEqual(result.previewRootBackground, result.bodyBackground, `${theme} preview card surface should differ from the page background.`);
+	assert.ok(result.iconNodes.every((node) => node.labelSurface === result.previewRootBackground), `${theme} icon labels should resolve the preview card as their nearest opaque background.`);
+	assert.equal(result.edgeColor, result.bodyColor, `${theme} edge labels should retain theme text color.`);
+	assert.ok(result.iconNodes.every((node) => node.labelColor !== result.edgeColor), `${theme} icon labels should remain semantically colored.`);
+	assert.notEqual(result.iconNodes[0]?.iconColor, result.iconNodes[1]?.iconColor, `${theme} gray and violet attribution icons should remain distinct.`);
+	assert.deepEqual(consoleErrors, [], `${theme} Mermaid rendering should not log console errors.`);
+	return result;
+}
 
+const darkMermaidResult = await assertMermaidIconBrowserRendering("dark");
+const lightMermaidResult = await assertMermaidIconBrowserRendering("light");
+assert.ok(
+	[...darkMermaidResult.iconNodes, ...lightMermaidResult.iconNodes].some((node) => node.iconColor !== node.labelColor),
+	"Surface-aware rendering should allow an icon glyph and label to use different compliant colors.",
+);
+
+async function assertMermaidFailurePropagation() {
+	const fixture = [
+		"flowchart LR",
+		'  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }',
+	].join("\n");
+	const { result, consoleErrors, servedFixtures } = await renderMermaidBrowserFixture("dark", fixture, { failIconPack: "lucide" });
+	assert.equal(result.mermaidRenderResult?.status, "failed", "Failed icon-pack loading should produce failed Mermaid status.");
+	assert.match(result.mermaidRenderResult?.error ?? "", /Failed to load Mermaid icon pack lucide: HTTP 503/);
+	assert.equal(result.failurePanel?.role, "alert", "Failed Mermaid rendering should expose an alert panel.");
+	assert.match(result.failurePanel?.text ?? "", /Mermaid render failed: Failed to load Mermaid icon pack lucide: HTTP 503/);
+	assert.deepEqual(servedFixtures, new Set(["mermaid", "failed:lucide"]), "Failure fixture should remain network-isolated.");
+	assert.ok(consoleErrors.some((message) => message.includes("Mermaid render failed:")), "Failed Mermaid rendering should log a browser diagnostic.");
+	assert.throws(
+		() => throwIfMermaidRenderFailed(result.mermaidRenderResult),
+		/Mermaid render failed: Failed to load Mermaid icon pack lucide: HTTP 503/,
+		"The production Puppeteer failure guard should reject serialized failed Mermaid status.",
+	);
+}
+
+await assertMermaidFailurePropagation();
+
+function extractReadmeMermaidIconFixture(readmeSource) {
+	const heading = /^### Mermaid icons\s*$/m.exec(readmeSource);
+	assert.ok(heading, "README should contain a Mermaid icons section.");
+	const remainder = readmeSource.slice(heading.index + heading[0].length);
+	const nextHeading = /^#{1,3}\s+\S/m.exec(remainder);
+	const section = nextHeading ? remainder.slice(0, nextHeading.index) : remainder;
+	const fence = /```mermaid[^\n]*\r?\n([\s\S]*?)\r?\n```/.exec(section);
+	assert.ok(fence?.[1]?.trim(), "README Mermaid icons section should contain a non-empty Mermaid fence.");
+	return fence[1].trim();
+}
+
+const readmeSource = await readFile(new URL("../README.md", import.meta.url), "utf8");
+const readmeMermaidIconFixture = extractReadmeMermaidIconFixture(readmeSource);
+const readmeIconMetadataLines = readmeMermaidIconFixture.split("\n").filter((line) => line.includes(" icon: "));
+assert.equal(readmeIconMetadataLines.length, 2, "README Mermaid example should document both supported icon packs.");
+for (const line of readmeIconMetadataLines) {
+	assert.match(
+		line,
+		/@\{[^{}\r\n]*icon:\s*"(?:lucide|logos):[^"]+"[^{}\r\n]*\}\s*$/,
+		"README icon metadata declarations should remain on one source line.",
+	);
+}
+
+async function assertReadmeMermaidIconRendering(theme) {
+	const { result, consoleErrors, servedFixtures } = await renderMermaidBrowserFixture(theme, readmeMermaidIconFixture);
+	assert.deepEqual(result.mermaidRenderResult, { status: "success" }, `${theme} README Mermaid example should render successfully.`);
+	assert.equal(result.failurePanel, null, `${theme} README Mermaid example should not show a failure panel.`);
+	assert.equal(result.iconCount, 2, `${theme} README Mermaid example should render both documented icons.`);
+	assert.deepEqual(result.iconNodes.map(({ label }) => label), ["Source", "GitHub"]);
+	assert.ok(result.iconNodes.every((node) => node.hasPath), `${theme} README Mermaid icons should contain SVG paths.`);
+	assert.deepEqual(servedFixtures, new Set(["mermaid", "lucide", "logos"]), `${theme} README Mermaid example should remain network-isolated.`);
+	for (const node of result.iconNodes) {
+		assert.ok(contrastRatio(node.iconColor, node.iconSurfaceFill) >= 4.5, `${theme} README icon glyphs should meet accessible contrast.`);
+		assert.ok(contrastRatio(node.labelColor, node.labelSurface) >= 4.5, `${theme} README icon labels should meet accessible contrast.`);
+	}
+	assert.deepEqual(consoleErrors, [], `${theme} README Mermaid example should not log console errors.`);
+}
+
+await assertReadmeMermaidIconRendering("dark");
+await assertReadmeMermaidIconRendering("light");
 function collectExtensionRegistrations() {
 	const commands = [];
 	const tools = [];

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -307,26 +307,40 @@ const transpiledIndexOutput = ts.transpileModule(src, {
 	},
 	fileName: sourcePath,
 }).outputText;
-const transpiledIndex = transpiledIndexOutput.replace(
+const transpiledIndexWithFailureGuard = transpiledIndexOutput.replace(
 	"function throwIfMermaidRenderFailed(mermaidResult) {",
 	"export function throwIfMermaidRenderFailed(mermaidResult) {",
 );
-assert.notEqual(transpiledIndex, transpiledIndexOutput, "Regression harness should expose the production Mermaid failure guard only in transpiled test output.");
+assert.notEqual(transpiledIndexWithFailureGuard, transpiledIndexOutput, "Regression harness should expose the production Mermaid failure guard only in transpiled test output.");
+const transpiledIndex = transpiledIndexWithFailureGuard.replace(
+	"function usesSupportedMermaidIconPack(source) {",
+	"export function usesSupportedMermaidIconPack(source) {",
+);
+assert.notEqual(transpiledIndex, transpiledIndexWithFailureGuard, "Regression harness should expose the production Mermaid icon-pack detector only in transpiled test output.");
 
 let extensionFactory;
 let buildMermaidBrowserModule;
 let getPreviewBrowserLaunchOptions;
 let throwIfMermaidRenderFailed;
+let usesSupportedMermaidIconPack;
 try {
 	await writeFile(transpiledIndexPath, transpiledIndex, "utf8");
-	({ default: extensionFactory, buildMermaidBrowserModule, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
+	({ default: extensionFactory, buildMermaidBrowserModule, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed, usesSupportedMermaidIconPack } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
 } finally {
 	await rm(transpiledIndexPath, { force: true });
 }
 
 assert.match(src, /const RENDER_VERSION = "v25";/, "Observable Mermaid failures should advance beyond the Slice 1 cache epoch.");
 assert.match(src, /const MERMAID_BROWSER_VERSION = "11\.16\.0";/, "Browser Mermaid version should match the CLI validator.");
-assert.match(src, /"--iconPacks", \.\.\.MERMAID_CLI_ICON_PACKS/, "PDF Mermaid rendering should forward both icon packs.");
+assert.match(
+	src,
+	/if \(usesSupportedMermaidIconPack\(source\)\) \{\s*args\.push\("--iconPacks", \.\.\.MERMAID_CLI_ICON_PACKS\);\s*\}/,
+	"PDF Mermaid rendering should forward icon packs only when a supported icon is present.",
+);
+assert.equal(usesSupportedMermaidIconPack("flowchart LR\n  source --> target"), false, "Ordinary Mermaid diagrams should remain compatible with older Mermaid CLI versions.");
+assert.equal(usesSupportedMermaidIconPack('source@{ icon: "lucide:file-code-2", label: "Source" }'), true, "Lucide icon metadata should enable CLI icon packs.");
+assert.equal(usesSupportedMermaidIconPack('github@{ label: "GitHub", icon: "logos:github-icon" }'), true, "Logos icon metadata should enable CLI icon packs.");
+assert.equal(usesSupportedMermaidIconPack('custom@{ icon: "custom:thing", label: "Custom" }'), false, "Unregistered icon prefixes should not enable unrelated CLI packs.");
 assert.ok(src.includes("const mermaidResult = await browserPage!.evaluate"), "Puppeteer rendering should read structured Mermaid status.");
 assert.ok(src.includes("throwIfMermaidRenderFailed(mermaidResult);"), "Puppeteer rendering should invoke the production Mermaid failure guard.");
 assert.doesNotMatch(
@@ -569,6 +583,7 @@ function extractReadmeMermaidIconFixture(readmeSource) {
 }
 
 const readmeSource = await readFile(new URL("../README.md", import.meta.url), "utf8");
+assert.match(readmeSource, /PDF icon nodes require Mermaid CLI 11\.6\+\./, "README should document the Mermaid CLI version required for PDF icons.");
 const readmeMermaidIconFixture = extractReadmeMermaidIconFixture(readmeSource);
 const readmeIconMetadataLines = readmeMermaidIconFixture.split("\n").filter((line) => line.includes(" icon: "));
 assert.equal(readmeIconMetadataLines.length, 2, "README Mermaid example should document both supported icon packs.");

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -306,9 +306,27 @@ try {
 	await rm(transpiledIndexPath, { force: true });
 }
 
-assert.match(src, /const RENDER_VERSION = "v22";/, "Mermaid icon renderer should invalidate stale preview cache entries.");
+assert.match(src, /const RENDER_VERSION = "v23";/, "Mermaid contrast renderer should invalidate stale preview cache entries.");
 assert.match(src, /const MERMAID_BROWSER_VERSION = "11\.16\.0";/, "Browser Mermaid version should match the CLI validator.");
 assert.match(src, /"--iconPacks", \.\.\.MERMAID_CLI_ICON_PACKS/, "PDF Mermaid rendering should forward both icon packs.");
+
+const parseRgb = (value) => {
+	const channels = value.match(/[\d.]+/g)?.slice(0, 3).map(Number);
+	assert.equal(channels?.length, 3, `Expected an RGB color, received ${value}`);
+	return channels;
+};
+const relativeLuminance = (color) => {
+	const linear = color.map((channel) => {
+		const value = channel / 255;
+		return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+	});
+	return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+};
+const contrastRatio = (foreground, background) => {
+	const lighter = Math.max(relativeLuminance(parseRgb(foreground)), relativeLuminance(parseRgb(background)));
+	const darker = Math.min(relativeLuminance(parseRgb(foreground)), relativeLuminance(parseRgb(background)));
+	return (lighter + 0.05) / (darker + 0.05);
+};
 
 async function assertMermaidIconBrowserRendering(theme) {
 	const palette = theme === "dark"
@@ -317,12 +335,17 @@ async function assertMermaidIconBrowserRendering(theme) {
 	const fixture = [
 		"flowchart LR",
 		'  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }',
+		'  payload@{ shape: "doc", label: "Payload" }',
+		'  store@{ shape: "cyl", label: "Store" }',
+		'  midtone@{ shape: "rounded", label: "Midtone" }',
 		'  github@{ icon: "logos:github-icon", form: "rounded", label: "GitHub", pos: "b", h: 56 }',
-		"  source -->|publish| github",
+		"  source -->|prepare| payload -->|persist| store -->|review| midtone -->|publish| github",
 		"  classDef unchanged fill:#f8f9fa,stroke:#868e96,stroke-width:2px",
 		"  classDef changed fill:#f3f0ff,stroke:#7950f2,stroke-width:2px",
-		"  class source unchanged",
-		"  class github changed",
+		"  classDef midtone fill:#808080,stroke:#666666,stroke-width:2px",
+		"  class source,store unchanged",
+		"  class payload,github changed",
+		"  class midtone midtone",
 	].join("\n");
 	const mermaidConfig = {
 		startOnLoad: false,
@@ -384,7 +407,8 @@ async function assertMermaidIconBrowserRendering(theme) {
 			iconCount: document.querySelectorAll(".icon-shape svg").length,
 			edgeColor: getComputedStyle(document.querySelector(".edgeLabel")).color,
 			bodyColor: getComputedStyle(document.body).color,
-			nodes: Array.from(document.querySelectorAll(".icon-shape")).map((node) => {
+			bodyBackground: getComputedStyle(document.body).backgroundColor,
+			iconNodes: Array.from(document.querySelectorAll(".icon-shape")).map((node) => {
 				const label = node.querySelector(".nodeLabel");
 				const icon = node.querySelector("svg");
 				return {
@@ -394,15 +418,34 @@ async function assertMermaidIconBrowserRendering(theme) {
 					hasPath: Boolean(icon?.querySelector("path")),
 				};
 			}),
+			shapeNodes: Array.from(document.querySelectorAll(".node:not(.icon-shape)")).map((node) => {
+				const label = node.querySelector(".nodeLabel");
+				const shape = Array.from(node.querySelectorAll("rect, polygon, path, circle, ellipse")).find((candidate) => {
+					const fill = getComputedStyle(candidate).fill;
+					return fill && fill !== "none" && fill !== "rgba(0, 0, 0, 0)";
+				});
+				return {
+					label: label?.textContent?.trim(),
+					labelColor: getComputedStyle(label).color,
+					shapeFill: getComputedStyle(shape).fill,
+				};
+			}),
 		}));
 		assert.ok(result.iconCount >= 2, `${theme} icon rendering should render icon SVGs rather than placeholders.`);
-		assert.deepEqual(result.nodes.map(({ label }) => label), ["Source", "GitHub"]);
-		assert.ok(result.nodes.every((node) => node.hasPath), `${theme} icon nodes should contain rendered SVG paths.`);
+		assert.deepEqual(result.iconNodes.map(({ label }) => label), ["Source", "GitHub"]);
+		assert.ok(result.iconNodes.every((node) => node.hasPath), `${theme} icon nodes should contain rendered SVG paths.`);
+		assert.deepEqual(result.shapeNodes.map(({ label }) => label), ["Payload", "Store", "Midtone"]);
 		assert.deepEqual(servedFixtures, new Set(["mermaid", "lucide", "logos"]), `${theme} fixture rendering should not use the network.`);
-		for (const node of result.nodes) assert.equal(node.labelColor, node.iconColor, `${theme} icon label should inherit its icon color.`);
+		for (const node of result.iconNodes) {
+			assert.equal(node.labelColor, node.iconColor, `${theme} icon label should inherit its icon color.`);
+			assert.ok(contrastRatio(node.labelColor, result.bodyBackground) >= 4.5, `${theme} icon labels should meet accessible contrast.`);
+		}
+		for (const node of result.shapeNodes) {
+			assert.ok(contrastRatio(node.labelColor, node.shapeFill) >= 4.5, `${theme} shape labels should meet accessible contrast.`);
+		}
 		assert.equal(result.edgeColor, result.bodyColor, `${theme} edge labels should retain theme text color.`);
-		assert.ok(result.nodes.some((node) => node.labelColor !== result.edgeColor), `${theme} icon labels should remain semantically colored.`);
-		assert.notEqual(result.nodes[0]?.iconColor, result.nodes[1]?.iconColor, `${theme} gray and violet attribution icons should remain distinct.`);
+		assert.ok(result.iconNodes.some((node) => node.labelColor !== result.edgeColor), `${theme} icon labels should remain semantically colored.`);
+		assert.notEqual(result.iconNodes[0]?.iconColor, result.iconNodes[1]?.iconColor, `${theme} gray and violet attribution icons should remain distinct.`);
 		assert.deepEqual(consoleErrors, [], `${theme} Mermaid rendering should not log console errors.`);
 	} finally {
 		await browser.close();

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import puppeteer from "puppeteer-core";
 import ts from "typescript";
 
 const sourcePath = resolve(process.cwd(), "index.ts");
@@ -296,12 +297,120 @@ const transpiledIndex = ts.transpileModule(src, {
 }).outputText;
 
 let extensionFactory;
+let buildMermaidBrowserModule;
+let getPreviewBrowserLaunchOptions;
 try {
 	await writeFile(transpiledIndexPath, transpiledIndex, "utf8");
-	({ default: extensionFactory } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
+	({ default: extensionFactory, buildMermaidBrowserModule, getPreviewBrowserLaunchOptions } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
 } finally {
 	await rm(transpiledIndexPath, { force: true });
 }
+
+assert.match(src, /const RENDER_VERSION = "v22";/, "Mermaid icon renderer should invalidate stale preview cache entries.");
+assert.match(src, /const MERMAID_BROWSER_VERSION = "11\.16\.0";/, "Browser Mermaid version should match the CLI validator.");
+assert.match(src, /"--iconPacks", \.\.\.MERMAID_CLI_ICON_PACKS/, "PDF Mermaid rendering should forward both icon packs.");
+
+async function assertMermaidIconBrowserRendering(theme) {
+	const palette = theme === "dark"
+		? { background: "#0f1117", surface: "#171b24", text: "#e6edf3", line: "#9aa5b1" }
+		: { background: "#f5f7fb", surface: "#ffffff", text: "#1f2328", line: "#57606a" };
+	const fixture = [
+		"flowchart LR",
+		'  source@{ icon: "lucide:file-code-2", form: "rounded", label: "Source", pos: "b", h: 56 }',
+		'  github@{ icon: "logos:github-icon", form: "rounded", label: "GitHub", pos: "b", h: 56 }',
+		"  source -->|publish| github",
+		"  classDef unchanged fill:#f8f9fa,stroke:#868e96,stroke-width:2px",
+		"  classDef changed fill:#f3f0ff,stroke:#7950f2,stroke-width:2px",
+		"  class source unchanged",
+		"  class github changed",
+	].join("\n");
+	const mermaidConfig = {
+		startOnLoad: false,
+		theme: "base",
+		themeVariables: {
+			background: palette.background,
+			primaryColor: palette.surface,
+			primaryTextColor: palette.text,
+			secondaryColor: palette.surface,
+			secondaryTextColor: palette.text,
+			tertiaryColor: palette.surface,
+			tertiaryTextColor: palette.text,
+			textColor: palette.text,
+			lineColor: palette.line,
+			edgeLabelBackground: palette.surface,
+		},
+	};
+	const { executablePath, args } = getPreviewBrowserLaunchOptions();
+	const browser = await puppeteer.launch({ headless: true, executablePath, args });
+	try {
+		const page = await browser.newPage();
+		const consoleErrors = [];
+		page.on("console", (message) => { if (message.type() === "error") consoleErrors.push(message.text()); });
+		const fixtureRoot = resolve(process.cwd(), "node_modules");
+		const servedFixtures = new Set();
+		const iconFixtures = new Map([
+			["/@iconify-json/lucide@1/icons.json", { name: "lucide", path: resolve(fixtureRoot, "@iconify-json/lucide/icons.json") }],
+			["/@iconify-json/logos@1/icons.json", { name: "logos", path: resolve(fixtureRoot, "@iconify-json/logos/icons.json") }],
+		]);
+		await page.setRequestInterception(true);
+		page.on("request", async (request) => {
+			const url = new URL(request.url());
+			const mermaidFixture = url.hostname === "cdn.jsdelivr.net" && url.pathname.startsWith("/npm/mermaid@11.16.0/")
+				? resolve(fixtureRoot, "mermaid", url.pathname.slice("/npm/mermaid@11.16.0/".length))
+				: undefined;
+			const iconFixture = url.hostname === "unpkg.com" ? iconFixtures.get(url.pathname) : undefined;
+			const localPath = mermaidFixture ?? iconFixture?.path;
+			if (!localPath) {
+				if (url.hostname === "cdn.jsdelivr.net" || url.hostname === "unpkg.com") return request.abort("blockedbyclient");
+				return request.continue();
+			}
+			servedFixtures.add(mermaidFixture ? "mermaid" : iconFixture.name);
+			await request.respond({
+				body: await readFile(localPath),
+				contentType: localPath.endsWith(".json") ? "application/json" : "application/javascript",
+				headers: { "access-control-allow-origin": "*" },
+			});
+		});
+		const browserModule = buildMermaidBrowserModule(
+			JSON.stringify(mermaidConfig),
+			JSON.stringify([
+				{ name: "lucide", url: "https://unpkg.com/@iconify-json/lucide@1/icons.json" },
+				{ name: "logos", url: "https://unpkg.com/@iconify-json/logos@1/icons.json" },
+			]),
+		);
+		await page.setContent(`<!doctype html><body style="background:${palette.background};color:${palette.text}"><pre class="mermaid"><code>${fixture}</code></pre><script type="module">${browserModule}\n(async () => { try { await renderMermaid(); } finally { window.__mermaidDone = true; } })();</script></body>`, { waitUntil: "domcontentloaded" });
+		await page.waitForFunction(() => window.__mermaidDone === true, { timeout: 30000 });
+		const result = await page.evaluate(() => ({
+			iconCount: document.querySelectorAll(".icon-shape svg").length,
+			edgeColor: getComputedStyle(document.querySelector(".edgeLabel")).color,
+			bodyColor: getComputedStyle(document.body).color,
+			nodes: Array.from(document.querySelectorAll(".icon-shape")).map((node) => {
+				const label = node.querySelector(".nodeLabel");
+				const icon = node.querySelector("svg");
+				return {
+					label: label?.textContent?.trim(),
+					labelColor: getComputedStyle(label).color,
+					iconColor: getComputedStyle(icon).color,
+					hasPath: Boolean(icon?.querySelector("path")),
+				};
+			}),
+		}));
+		assert.ok(result.iconCount >= 2, `${theme} icon rendering should render icon SVGs rather than placeholders.`);
+		assert.deepEqual(result.nodes.map(({ label }) => label), ["Source", "GitHub"]);
+		assert.ok(result.nodes.every((node) => node.hasPath), `${theme} icon nodes should contain rendered SVG paths.`);
+		assert.deepEqual(servedFixtures, new Set(["mermaid", "lucide", "logos"]), `${theme} fixture rendering should not use the network.`);
+		for (const node of result.nodes) assert.equal(node.labelColor, node.iconColor, `${theme} icon label should inherit its icon color.`);
+		assert.equal(result.edgeColor, result.bodyColor, `${theme} edge labels should retain theme text color.`);
+		assert.ok(result.nodes.some((node) => node.labelColor !== result.edgeColor), `${theme} icon labels should remain semantically colored.`);
+		assert.notEqual(result.nodes[0]?.iconColor, result.nodes[1]?.iconColor, `${theme} gray and violet attribution icons should remain distinct.`);
+		assert.deepEqual(consoleErrors, [], `${theme} Mermaid rendering should not log console errors.`);
+	} finally {
+		await browser.close();
+	}
+}
+
+await assertMermaidIconBrowserRendering("dark");
+await assertMermaidIconBrowserRendering("light");
 
 function collectExtensionRegistrations() {
 	const commands = [];


### PR DESCRIPTION
## Summary
- add Mermaid 11.16 Lucide and Logos icon-pack rendering in browser previews and PDF export
- resolve Pi-local Mermaid CLI and use the configured browser for rendering
- keep semantic icon colors while correcting labels to accessible contrast in light and dark themes

## Verification
- `npm run typecheck`
- `npm run check:readme-commands`
- `npm run check:regressions`