### PR TITLE
Fix Windows browser discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Set `PUPPETEER_EXECUTABLE_PATH` to override Chromium detection for terminal prev
 export PUPPETEER_EXECUTABLE_PATH=/path/to/chromium
 ```
 
+On Windows, standard system and per-user Chrome, Edge, Brave, and Chromium installations are detected from `ProgramW6432`, `PROGRAMFILES`, `PROGRAMFILES(X86)`, and `LOCALAPPDATA`, with the common `C:` locations as fallbacks.
+
 Terminal preview uses the known-good fixed screenshot path: 1200px Chromium viewport at device scale `2`. Set `PI_MARKDOWN_PREVIEW_DEVICE_SCALE_FACTOR` only if you want to experiment with screenshot density manually (default: `2`; range: `1`–`2.5`):
 
 ```bash

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { basename, dirname, extname, join, resolve as resolvePath } from "node:path";
+import { basename, dirname, extname, join, resolve as resolvePath, win32 as win32Path } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer-core";
 import { Type, type TUnsafe } from "typebox";
@@ -1601,8 +1601,46 @@ function hasMarkdownDiffFence(markdown: string): boolean {
 	return false;
 }
 
-function getBrowserCandidates(): string[] {
-	if (process.platform === "darwin") {
+function deduplicateWindowsPaths(paths: Array<string | undefined>): string[] {
+	const candidates: string[] = [];
+	const seen = new Set<string>();
+	for (const candidate of paths) {
+		if (!candidate?.trim()) continue;
+		const normalized = win32Path.normalize(candidate.trim());
+		const key = normalized.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		candidates.push(normalized);
+	}
+	return candidates;
+}
+
+function getWindowsBrowserCandidates(env: NodeJS.ProcessEnv): string[] {
+	const systemRoots = deduplicateWindowsPaths([
+		env.ProgramW6432,
+		env.PROGRAMFILES,
+		env["PROGRAMFILES(X86)"],
+		"C:/Program Files",
+		"C:/Program Files (x86)",
+	]);
+	const browserRelativePaths = [
+		["Google", "Chrome", "Application", "chrome.exe"],
+		["Microsoft", "Edge", "Application", "msedge.exe"],
+		["BraveSoftware", "Brave-Browser", "Application", "brave.exe"],
+		["Chromium", "Application", "chrome.exe"],
+	];
+	const systemCandidates = browserRelativePaths.flatMap((relativePath) => (
+		systemRoots.map((root) => win32Path.join(root, ...relativePath))
+	));
+	const localRoot = env.LOCALAPPDATA?.trim();
+	const userCandidates = localRoot
+		? browserRelativePaths.map((relativePath) => win32Path.join(localRoot, ...relativePath))
+		: [];
+	return deduplicateWindowsPaths([...systemCandidates, ...userCandidates]);
+}
+
+function getBrowserCandidates(platform: NodeJS.Platform = process.platform, env: NodeJS.ProcessEnv = process.env): string[] {
+	if (platform === "darwin") {
 		return [
 			"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
 			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -1612,13 +1650,8 @@ function getBrowserCandidates(): string[] {
 		];
 	}
 
-	if (process.platform === "win32") {
-		return [
-			"C:/Program Files/Google/Chrome/Application/chrome.exe",
-			"C:/Program Files (x86)/Google/Chrome/Application/chrome.exe",
-			"C:/Program Files/Microsoft/Edge/Application/msedge.exe",
-			"C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe",
-		];
+	if (platform === "win32") {
+		return getWindowsBrowserCandidates(env);
 	}
 
 	return [
@@ -1630,12 +1663,16 @@ function getBrowserCandidates(): string[] {
 	];
 }
 
-function findBrowserExecutable(): string | undefined {
-	const envPath = process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME_PATH || process.env.BROWSER;
-	if (envPath && existsSync(envPath)) {
+function findBrowserExecutable(
+	platform: NodeJS.Platform = process.platform,
+	env: NodeJS.ProcessEnv = process.env,
+	pathExists: (path: string) => boolean = existsSync,
+): string | undefined {
+	const envPath = env.PUPPETEER_EXECUTABLE_PATH || env.CHROME_PATH || env.BROWSER;
+	if (envPath && pathExists(envPath)) {
 		return envPath;
 	}
-	return getBrowserCandidates().find((candidate) => existsSync(candidate));
+	return getBrowserCandidates(platform, env).find((candidate) => pathExists(candidate));
 }
 
 let sharedPreviewBrowser: puppeteer.Browser | undefined;

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { resolve, win32 as win32Path } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer-core";
 import ts from "typescript";
@@ -333,6 +333,8 @@ for (const functionName of [
 	"usesSupportedMermaidIconPack",
 	"buildBlockAwarePageClips",
 	"collectPreviewPageLayout",
+	"findBrowserExecutable",
+	"getBrowserCandidates",
 ]) {
 	transpiledIndex = exposeTranspiledFunction(transpiledIndex, functionName);
 }
@@ -341,12 +343,14 @@ let extensionFactory;
 let buildBlockAwarePageClips;
 let buildMermaidBrowserModule;
 let collectPreviewPageLayout;
+let findBrowserExecutable;
+let getBrowserCandidates;
 let getPreviewBrowserLaunchOptions;
 let throwIfMermaidRenderFailed;
 let usesSupportedMermaidIconPack;
 try {
 	await writeFile(transpiledIndexPath, transpiledIndex, "utf8");
-	({ default: extensionFactory, buildBlockAwarePageClips, buildMermaidBrowserModule, collectPreviewPageLayout, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed, usesSupportedMermaidIconPack } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
+	({ default: extensionFactory, buildBlockAwarePageClips, buildMermaidBrowserModule, collectPreviewPageLayout, findBrowserExecutable, getBrowserCandidates, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed, usesSupportedMermaidIconPack } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
 } finally {
 	await rm(transpiledIndexPath, { force: true });
 }
@@ -362,6 +366,44 @@ assert.equal(usesSupportedMermaidIconPack("flowchart LR\n  source --> target"), 
 assert.equal(usesSupportedMermaidIconPack('source@{ icon: "lucide:file-code-2", label: "Source" }'), true, "Lucide icon metadata should enable CLI icon packs.");
 assert.equal(usesSupportedMermaidIconPack('github@{ label: "GitHub", icon: "logos:github-icon" }'), true, "Logos icon metadata should enable CLI icon packs.");
 assert.equal(usesSupportedMermaidIconPack('custom@{ icon: "custom:thing", label: "Custom" }'), false, "Unregistered icon prefixes should not enable unrelated CLI packs.");
+
+const edgeX86Path = win32Path.join("C:/Program Files (x86)", "Microsoft", "Edge", "Application", "msedge.exe");
+const defaultWindowsBrowserCandidates = getBrowserCandidates("win32", {});
+assert.ok(
+	defaultWindowsBrowserCandidates.includes(edgeX86Path),
+	"Windows browser discovery should include Edge under Program Files (x86).",
+);
+const customWindowsEnv = {
+	ProgramW6432: "D:/Program Files",
+	PROGRAMFILES: "D:/Program Files",
+	"PROGRAMFILES(X86)": "D:/Program Files (x86)",
+	LOCALAPPDATA: "E:/Users/Ryan/AppData/Local",
+};
+const customWindowsBrowserCandidates = getBrowserCandidates("win32", customWindowsEnv);
+const customEdgeX86Path = win32Path.join(customWindowsEnv["PROGRAMFILES(X86)"], "Microsoft", "Edge", "Application", "msedge.exe");
+const perUserEdgePath = win32Path.join(customWindowsEnv.LOCALAPPDATA, "Microsoft", "Edge", "Application", "msedge.exe");
+assert.ok(customWindowsBrowserCandidates.includes(customEdgeX86Path), "Windows discovery should honor the PROGRAMFILES(X86) environment root.");
+assert.ok(customWindowsBrowserCandidates.includes(perUserEdgePath), "Windows discovery should include per-user Edge installations under LOCALAPPDATA.");
+assert.equal(
+	customWindowsBrowserCandidates.filter((candidate) => candidate === win32Path.join(customWindowsEnv.PROGRAMFILES, "Google", "Chrome", "Application", "chrome.exe")).length,
+	1,
+	"Equivalent Windows program-file roots should not create duplicate browser candidates.",
+);
+assert.equal(
+	findBrowserExecutable("win32", {}, (candidate) => candidate.toLowerCase() === edgeX86Path.toLowerCase()),
+	edgeX86Path,
+	"Windows discovery should select Edge from Program Files (x86) when it is the installed candidate.",
+);
+const explicitBrowserPath = "Z:\\Portable\\Chromium\\chrome.exe";
+assert.equal(
+	findBrowserExecutable(
+		"win32",
+		{ ...customWindowsEnv, PUPPETEER_EXECUTABLE_PATH: explicitBrowserPath },
+		(candidate) => candidate === explicitBrowserPath || candidate === customEdgeX86Path,
+	),
+	explicitBrowserPath,
+	"PUPPETEER_EXECUTABLE_PATH should remain higher priority than discovered Windows installations.",
+);
 
 assert.deepEqual(
 	buildBlockAwarePageClips(2500, [880, 1700], [], 1000, 10),


### PR DESCRIPTION
## Summary

- discover Windows browser installations from `ProgramW6432`, `PROGRAMFILES`, `PROGRAMFILES(X86)`, and `LOCALAPPDATA`
- include Microsoft Edge under `Program Files (x86)` and common per-user install locations
- retain common `C:` fallbacks and explicit browser-path override precedence
- deduplicate equivalent Windows paths case-insensitively

## Validation

- `npm run typecheck`
- `npm run check:readme-commands`
- `npm run check:regressions`
- clean standard Pi 0.83.0 local-package smoke test: all four commands registered, two-page fixture rendered, no extension errors
- OMP 17.2.1 compatibility smoke test: all four commands registered and `/preview --help` succeeded
- npm pack dry run excludes local `attachments/`

Windows path construction and selection are covered deterministically on macOS using `node:path.win32` and an injected filesystem predicate. Launching a real Windows Edge process still needs confirmation on Windows.

Fixes #8