### PR TITLE
Keep optional enum schemas composable across Pi hosts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -78,12 +78,13 @@ function shouldRegisterPreviewExportTool(): boolean {
 }
 
 function stringEnum<T extends readonly string[]>(values: T, options?: { description?: string; default?: T[number] }): TUnsafe<T[number]> {
-	return Type.Unsafe({
-		type: "string",
+	// Keep the literal-union static type while returning a composable string schema.
+	// Some compatible hosts cannot wrap Type.Unsafe schemas with Type.Optional.
+	return Type.String({
 		enum: values,
 		...(options?.description ? { description: options.description } : {}),
 		...(options?.default ? { default: options.default } : {}),
-	});
+	}) as unknown as TUnsafe<T[number]>;
 }
 
 type ThemeMode = "dark" | "light";

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer-core";
 import ts from "typescript";
+import { Check } from "typebox/value";
 
 const sourcePath = resolve(process.cwd(), "index.ts");
 const src = readFileSync(sourcePath, "utf-8");
@@ -19,6 +20,11 @@ assert.ok(
 		&& src.includes('typeof PiTuiCompat.allocateImageId === "function"')
 		&& src.includes("allocateImageIdIfAvailable?.()"),
 	"Kitty image IDs should be feature-detected and omitted when the host does not expose an allocator.",
+);
+const stringEnumSource = src.slice(src.indexOf("function stringEnum"), src.indexOf("type ThemeMode"));
+assert.ok(
+	stringEnumSource.includes("return Type.String({") && !stringEnumSource.includes("return Type.Unsafe({"),
+	"String enums should remain composable with Type.Optional in compatible host schema implementations.",
 );
 
 assert.match(src, /function buildRenderCacheKey\s*\(/, "Missing buildRenderCacheKey helper.");
@@ -709,7 +715,7 @@ await assertReadmeMermaidIconRendering("dark");
 await assertReadmeMermaidIconRendering("light");
 function collectExtensionRegistrations() {
 	const commands = [];
-	const tools = [];
+	const toolDefinitions = [];
 	const events = [];
 	const pi = {
 		on(event) {
@@ -719,22 +725,35 @@ function collectExtensionRegistrations() {
 			commands.push(name);
 		},
 		registerTool(definition) {
-			tools.push(definition.name);
+			toolDefinitions.push(definition);
 		},
 	};
 	extensionFactory(pi);
-	return { commands, tools, events };
+	return { commands, tools: toolDefinitions.map((definition) => definition.name), toolDefinitions, events };
 }
 
 const exportToolEnvName = "PI_MARKDOWN_PREVIEW_REGISTER_EXPORT_TOOL";
 const previousExportToolEnv = process.env[exportToolEnvName];
 try {
 	delete process.env[exportToolEnvName];
+	const defaultRegistrations = collectExtensionRegistrations();
 	assert.deepEqual(
-		collectExtensionRegistrations().tools,
+		defaultRegistrations.tools,
 		["preview_export"],
 		"preview_export should remain registered by default for backward compatibility.",
 	);
+	const previewExportParameters = defaultRegistrations.toolDefinitions[0].parameters;
+	assert.deepEqual(previewExportParameters.required, ["format"], "Only preview_export format should be required.");
+	assert.deepEqual(previewExportParameters.properties.format.enum, ["pdf", "html", "png"], "preview_export format should retain its enum values.");
+	assert.deepEqual(previewExportParameters.properties.source.enum, ["last_assistant", "file", "markdown"], "Optional preview_export source should retain its enum values.");
+	assert.deepEqual(previewExportParameters.properties.inputFormat.enum, ["markdown", "latex"], "Optional preview_export input format should retain its enum values.");
+	assert.equal(previewExportParameters.properties.source.type, "string", "Optional enum properties should remain string schemas.");
+	assert.equal(Check(previewExportParameters, { format: "pdf" }), true, "preview_export should accept required parameters without optional fields.");
+	assert.equal(Check(previewExportParameters, { format: "png", source: "file", path: "report.md", inputFormat: "markdown" }), true, "preview_export should accept valid optional enum values.");
+	assert.equal(Check(previewExportParameters, { format: "docx" }), false, "preview_export should reject invalid format values.");
+	assert.equal(Check(previewExportParameters, { format: "pdf", source: "other" }), false, "preview_export should reject invalid optional enum values.");
+	assert.equal(Check(previewExportParameters, { source: "file" }), false, "preview_export should continue requiring format.");
+	assert.equal(Check(previewExportParameters, { format: "pdf", unexpected: true }), false, "preview_export should continue rejecting additional properties.");
 
 	for (const disabledValue of ["0", "false", "FALSE", " no ", "off"]) {
 		process.env[exportToolEnvName] = disabledValue;


### PR DESCRIPTION
## Summary

- construct string enums with `Type.String({ enum: ... })` rather than `Type.Unsafe(...)`
- preserve the existing literal-union TypeScript inference
- preserve the exact JSON Schema shape used by standard Pi and model providers
- avoid OMP 17.2.9 failing when `Type.Optional` wraps an unsafe enum schema
- add validation regressions for required fields, optional enum values, invalid values, and additional properties

## Validation

- `npm run typecheck`
- `npm run check:readme-commands`
- `npm run check:regressions`
- standard Pi 0.83.0: all four commands registered; two-page preview rendered; no extension errors
- OMP 17.2.9: all four commands registered; two-page preview rendered; no extension errors
- OMP 17.2.1: all four commands registered; `/preview --help` succeeded; no extension errors
- npm pack dry run excludes local `attachments/`

The old and new helpers serialize to the same `{ type: "string", enum: [...] }` JSON schema. The runtime change is only that the schema remains a composable string type for hosts that implement `Type.Optional` by extending the inner schema.