### PR TITLE
Respect PI_CODING_AGENT_DIR for preview cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,9 @@ export MERMAID_PDF_THEME=default
 
 ## Cache
 
-Rendered previews are cached at `~/.pi/cache/markdown-preview/`. Clear with:
+Rendered previews are cached at `~/.pi/cache/markdown-preview/` by default.
+When `PI_CODING_AGENT_DIR` is set, the cache is stored at `$PI_CODING_AGENT_DIR/cache/markdown-preview/` instead.
+Clear it with:
 
 ```bash
 /preview-clear-cache
@@ -224,7 +226,7 @@ Rendered previews are cached at `~/.pi/cache/markdown-preview/`. Clear with:
 Or manually:
 
 ```bash
-rm -rf ~/.pi/cache/markdown-preview/
+rm -rf "${PI_CODING_AGENT_DIR:-$HOME/.pi}/cache/markdown-preview/"
 ```
 
 ## License

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,42 @@ const allocateImageIdIfAvailable = typeof PiTuiCompat.allocateImageId === "funct
 	? PiTuiCompat.allocateImageId
 	: undefined;
 
-const CACHE_DIR = join(homedir(), ".pi", "cache", "markdown-preview");
+function resolvePiAgentDir(
+	environment: NodeJS.ProcessEnv = process.env,
+	homeDirectory = homedir(),
+): string {
+	const configured = environment.PI_CODING_AGENT_DIR;
+	if (!configured) return join(homeDirectory, ".pi", "agent");
+	if (configured === "~") return homeDirectory;
+	if (configured.startsWith("~/") || configured.startsWith("~\\")) {
+		return join(homeDirectory, configured.slice(2));
+	}
+	return configured;
+}
+
+function getPreviewCacheDir(
+	environment: NodeJS.ProcessEnv = process.env,
+	homeDirectory = homedir(),
+): string {
+	if (!environment.PI_CODING_AGENT_DIR) {
+		// Keep the established default while containing custom Pi state under its explicit agent directory.
+		return join(homeDirectory, ".pi", "cache", "markdown-preview");
+	}
+	return join(resolvePiAgentDir(environment, homeDirectory), "cache", "markdown-preview");
+}
+
+function getPiManagedMermaidCliPath(
+	environment: NodeJS.ProcessEnv = process.env,
+	homeDirectory = homedir(),
+): string {
+	return join(
+		resolvePiAgentDir(environment, homeDirectory),
+		"npm", "node_modules", ".bin",
+		process.platform === "win32" ? "mmdc.cmd" : "mmdc",
+	);
+}
+
+const CACHE_DIR = getPreviewCacheDir();
 const MERMAID_PDF_CACHE_DIR = join(CACHE_DIR, "mermaid-pdf");
 const PREVIEW_ANNOTATION_PLACEHOLDER_PREFIX = "PIMDPREVIEWANNOT";
 const ANNOTATION_HELPERS_SOURCE = readFileSync(new URL("./client/annotation-helpers.js", import.meta.url), "utf-8");
@@ -49,10 +84,7 @@ const MERMAID_BROWSER_ICON_PACKS = [
 	{ name: "lucide", url: "https://unpkg.com/@iconify-json/lucide@1/icons.json" },
 	{ name: "logos", url: "https://unpkg.com/@iconify-json/logos@1/icons.json" },
 ] as const;
-const PI_MERMAID_CLI_PATH = join(
-	homedir(), ".pi", "agent", "npm", "node_modules", ".bin",
-	process.platform === "win32" ? "mmdc.cmd" : "mmdc",
-);
+const PI_MERMAID_CLI_PATH = getPiManagedMermaidCliPath();
 const DEFAULT_TERMINAL_PREVIEW_FONT_SIZE_PX = 16;
 const DEFAULT_BROWSER_PREVIEW_FONT_SIZE_PX = 15;
 const MIN_PREVIEW_FONT_SIZE_PX = 10;
@@ -4529,7 +4561,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("preview-clear-cache", {
-		description: "Clear rendered preview cache (~/.pi/cache/markdown-preview)",
+		description: `Clear rendered preview cache (${CACHE_DIR})`,
 		handler: async (_args, ctx) => {
 			await ctx.waitForIdle();
 			try {

--- a/test/regressions.mjs
+++ b/test/regressions.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
-import { resolve, win32 as win32Path } from "node:path";
+import { join, resolve, win32 as win32Path } from "node:path";
 import { pathToFileURL } from "node:url";
 import puppeteer from "puppeteer-core";
 import ts from "typescript";
@@ -335,6 +335,9 @@ for (const functionName of [
 	"collectPreviewPageLayout",
 	"findBrowserExecutable",
 	"getBrowserCandidates",
+	"getPiManagedMermaidCliPath",
+	"getPreviewCacheDir",
+	"resolvePiAgentDir",
 ]) {
 	transpiledIndex = exposeTranspiledFunction(transpiledIndex, functionName);
 }
@@ -345,15 +348,57 @@ let buildMermaidBrowserModule;
 let collectPreviewPageLayout;
 let findBrowserExecutable;
 let getBrowserCandidates;
+let getPiManagedMermaidCliPath;
 let getPreviewBrowserLaunchOptions;
+let getPreviewCacheDir;
+let resolvePiAgentDir;
 let throwIfMermaidRenderFailed;
 let usesSupportedMermaidIconPack;
 try {
 	await writeFile(transpiledIndexPath, transpiledIndex, "utf8");
-	({ default: extensionFactory, buildBlockAwarePageClips, buildMermaidBrowserModule, collectPreviewPageLayout, findBrowserExecutable, getBrowserCandidates, getPreviewBrowserLaunchOptions, throwIfMermaidRenderFailed, usesSupportedMermaidIconPack } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
+	({ default: extensionFactory, buildBlockAwarePageClips, buildMermaidBrowserModule, collectPreviewPageLayout, findBrowserExecutable, getBrowserCandidates, getPiManagedMermaidCliPath, getPreviewBrowserLaunchOptions, getPreviewCacheDir, resolvePiAgentDir, throwIfMermaidRenderFailed, usesSupportedMermaidIconPack } = await import(`${pathToFileURL(transpiledIndexPath).href}?test=${Date.now()}`));
 } finally {
 	await rm(transpiledIndexPath, { force: true });
 }
+
+const testHomeDirectory = join(process.cwd(), ".pi-markdown-preview-test-home");
+const customPiAgentDir = join(testHomeDirectory, ".local", "share", "pi");
+assert.equal(
+	resolvePiAgentDir({}, testHomeDirectory),
+	join(testHomeDirectory, ".pi", "agent"),
+	"Pi agent directory resolution should preserve the standard default.",
+);
+assert.equal(
+	getPreviewCacheDir({}, testHomeDirectory),
+	join(testHomeDirectory, ".pi", "cache", "markdown-preview"),
+	"Preview caching should preserve the standard default location.",
+);
+assert.equal(
+	resolvePiAgentDir({ PI_CODING_AGENT_DIR: customPiAgentDir }, testHomeDirectory),
+	customPiAgentDir,
+	"Pi agent directory resolution should honor PI_CODING_AGENT_DIR.",
+);
+assert.equal(
+	getPreviewCacheDir({ PI_CODING_AGENT_DIR: customPiAgentDir }, testHomeDirectory),
+	join(customPiAgentDir, "cache", "markdown-preview"),
+	"Preview caching should stay under a custom Pi agent directory.",
+);
+assert.equal(
+	getPreviewCacheDir({ PI_CODING_AGENT_DIR: "~/custom-pi" }, testHomeDirectory),
+	join(testHomeDirectory, "custom-pi", "cache", "markdown-preview"),
+	"Preview caching should expand a home-relative Pi agent directory.",
+);
+const mermaidCliExecutable = process.platform === "win32" ? "mmdc.cmd" : "mmdc";
+assert.equal(
+	getPiManagedMermaidCliPath({}, testHomeDirectory),
+	join(testHomeDirectory, ".pi", "agent", "npm", "node_modules", ".bin", mermaidCliExecutable),
+	"Managed Mermaid CLI discovery should preserve the standard Pi agent directory.",
+);
+assert.equal(
+	getPiManagedMermaidCliPath({ PI_CODING_AGENT_DIR: customPiAgentDir }, testHomeDirectory),
+	join(customPiAgentDir, "npm", "node_modules", ".bin", mermaidCliExecutable),
+	"Managed Mermaid CLI discovery should stay under a custom Pi agent directory.",
+);
 
 assert.match(src, /const RENDER_VERSION = "v26";/, "Block-aware pagination should invalidate fixed-slice preview caches.");
 assert.match(src, /const MERMAID_BROWSER_VERSION = "11\.16\.0";/, "Browser Mermaid version should match the CLI validator.");


### PR DESCRIPTION
## Summary

- keep the existing `~/.pi/cache/markdown-preview` default when no override is configured
- store caches and default preview artifacts under `$PI_CODING_AGENT_DIR/cache/markdown-preview` when the agent directory is overridden
- resolve the Pi-managed Mermaid CLI from the overridden agent directory as well
- show the resolved cache path in `/preview-clear-cache` and document the custom location
- cover default, custom, and home-relative agent paths with regression checks

## Validation

- `npm run typecheck`
- `npm run check:readme-commands`
- `npm run check:regressions`
- `PI_CODING_AGENT_DIR=<temporary-path> npm run check:regressions`
- `npm pack --dry-run --json`

Fixes #11